### PR TITLE
feat: do not consider intermediate performance results from branches

### DIFF
--- a/git-perf
+++ b/git-perf
@@ -208,6 +208,7 @@ def get_raw_notes(max_count_commits: int, offset: int = 0) -> str:
                'log',
                '-n', str(max_count_commits),
                '--ignore-missing',  # Support empty repos
+               '--first-parent',  # only show the main branch history
                '--skip', str(offset),
                '--no-color',
                '--pretty=--,%H,%D%n%N',

--- a/test.sh
+++ b/test.sh
@@ -411,6 +411,37 @@ if [[ ${output} != *'does-not-exist'* ]]; then
   exit 1
 fi
 
+# Check that only first parents for a merged branch are considered
+# Create steady (stddev == 0) measurement on main branch with flaky
+# results on merged branch's intermediate commits.
+# Producing another flaky result on the main branch after merging will
+# only pass the audit if the merged branch's history is considered.
+cd_empty_repo
+create_commit
+git perf add -m timer 1
+create_commit
+git perf add -m timer 1
+create_commit
+git perf add -m timer 5
+# Base test: Expect this to fail
+git perf audit -m timer && exit 1
+git checkout HEAD~1
+git checkout -b feature_branch
+create_commit
+# Bad intermediate result
+git perf add -m timer 5
+create_commit
+# Fixed perf in this commit
+git perf add -m timer 1
+git checkout -
+# Merged feature_branch has ok performance
+git merge --no-ff -
+git perf add -m timer 1
+# True performance regression on main branch must fail
+create_commit
+git perf add -m timer 2
+git perf audit -m timer && exit 1
+
 
 exit 0
 


### PR DESCRIPTION
If branches are merged with a merge commit, the intermediate results
from the features branches should not contribute to the history of
the main branch. More so, since many of the commits from the feature
branches might not even have a performance result. This would reduce
the depth of the history for the performance records.