### PR TITLE
ci: handle concurrency on master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test git-perf
 # TODO(kaihowl) deeper test with merge-based PR workflow (HEAD == merge commit)
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
`head_ref` is only known for PRs with a target branch. For all other
branches (and including PRs) `ref` is the right attribute to use.