### PR TITLE
fix: align meaning of '-n' flag for audit and report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # TODO(kaihowl) is there an off-by one?
-          fetch-depth: 41
+          fetch-depth: 40
       - uses: fregante/setup-git-user@v1
       - name: Install and test
         shell: bash
@@ -51,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 41
+          fetch-depth: 40
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
       - name: use commit name as report name

--- a/git-perf
+++ b/git-perf
@@ -137,7 +137,7 @@ audit_parser.add_argument(
 audit_parser.add_argument(
     '-n',
     '--max-count',
-    help='Limit to the number of previous commits considered',
+    help='Limit to the number of commits considered',
     type=int,
     default=DEFAULT_MAX_COUNT)
 audit_parser.add_argument(
@@ -443,8 +443,17 @@ def audit(measurement: str,
           sigma: float):
     import numpy as np
 
-    df, _ = get_df(max_count, offset=1)
-    df_head, _ = get_df(1)
+    df, commits = get_df(max_count)
+
+    # TODO(kaihowl) test missing
+    if len(df) == 0:
+        print("No performance measurements found", file=sys.stderr)
+        sys.exit(1)
+
+    ic(df.to_markdown())
+
+    df_head = df[df['commit'] == commits[0]]
+    df_tail = df[df['commit'] != commits[0]]
 
     if len(df_head) == 0:
         print("No performance measurements on HEAD commit", file=sys.stderr)
@@ -455,7 +464,7 @@ def audit(measurement: str,
     selector.append(('name', measurement))
     # The historical data allows for non-existent filters
     try:
-        df = filter_df(df, selector)
+        df_tail = filter_df(df_tail, selector)
     except ValueError as e:
         print(e, file=sys.stderr)
 
@@ -469,10 +478,12 @@ def audit(measurement: str,
 
     accept_regression = len(trailers) > 0
 
-    ic(df.to_markdown())
-    mean, std = summarize(df, group_by, aggregate_by)
-    print(f"mean: {mean}")
-    print(f"std: {std}")
+    ic(df_head.to_markdown())
+    ic(df_tail.to_markdown())
+
+    tail_mean, tail_std = summarize(df_tail, group_by, aggregate_by)
+    print(f"mean: {tail_mean}")
+    print(f"std: {tail_std}")
 
     head_mean, _ = summarize(df_head, group_by, aggregate_by)
     print(f"head_mean: {head_mean}")
@@ -482,7 +493,7 @@ def audit(measurement: str,
         print("No matching measurements in HEAD commit", file=sys.stderr)
         sys.exit(1)
 
-    if np.isnan(std):
+    if np.isnan(tail_std):
         print("Not enough historical data available", file=sys.stderr)
         return
 
@@ -492,7 +503,7 @@ def audit(measurement: str,
     # 0/0 = np.nan(0)
     # z/0 = np.nan(+inf) if z > 0
     with np.errstate(divide='ignore'):
-        z = abs(head_mean - mean) / std
+        z = abs(head_mean - tail_mean) / tail_std
     z = np.nan_to_num(z)
     print(f"z-score: {z}")
     is_regular = z <= sigma

--- a/test/test_shallow.sh
+++ b/test/test_shallow.sh
@@ -21,21 +21,22 @@ cd "$(mktemp -d)"
 git clone "file://$full_repo" --depth=2 shallow_clone
 cd shallow_clone
 git perf pull
-git perf report -n 1
-output=$(git perf report -n 10 2>&1 1>/dev/null) && exit 1
+git perf report -n 2
+git perf audit -n 2 -m test-measure
+output=$(git perf report -n 3 2>&1 1>/dev/null) && exit 1
 if [[ ${output} != *'shallow clone'* ]]; then
   echo Missing warning for 'shallow clone'
   echo "$output"
   exit 1
 fi
-output=$(git perf audit -n 10 -m test-measure 2>&1 1>/dev/null) && exit 1
+output=$(git perf audit -n 3 -m test-measure 2>&1 1>/dev/null) && exit 1
 if [[ ${output} != *'shallow clone'* ]]; then
   echo Missing warning for 'shallow clone'
   echo "$output"
   exit 1
 fi
 
-# The shallow warning for a PR-branch with a merge as HEAD should be counting the first parents history.
+# The shallow warning for a PR-branch with a merge as HEAD should be counting the first parent's history.
 # This is already the default behavior for git-fetch with the depth option.
 cd_temp_repo
 full_repo=$(pwd)
@@ -50,11 +51,15 @@ done
 git checkout -
 git merge --no-ff -
 # Test first-parent fetch-depth behavior even if HEAD is non-merge commit.
-create_commit
+commit=$(git rev-parse HEAD)
 # Shallow clone with depth == 10 for main branch
 cd "$(mktemp -d)"
-git clone "file://$full_repo" --depth=10 shallow_clone
-cd shallow_clone
+git init
+git remote add origin "file://$full_repo"
+# Simulate the behavior of github actions checkout closely
+git fetch origin "$commit:local-ref" --depth=10
+git checkout local-ref
+git perf pull
 # Must fail as this expects more history
 output=$(git perf report -n 11 2>&1 1>/dev/null) && exit 1
 if [[ ${output} != *'shallow clone'* ]]; then
@@ -62,7 +67,6 @@ if [[ ${output} != *'shallow clone'* ]]; then
   echo "$output"
   exit 1
 fi
-git perf pull
 # Must work as this is the exact history length
 # If we erroneously considered the feature_branch's history, it would be filtered
 # out and we end up with fewer than 10 commits when following the first parent.


### PR DESCRIPTION
Both should consider the same commits. Report just takes a look back
for <n> commits including HEAD. Audit looks at the same range, but
separates HEAD and the tail commits for correct statistics.