### PR TITLE
fix: missing selectors do not skip other selectors

### DIFF
--- a/git-perf
+++ b/git-perf
@@ -9,6 +9,7 @@ import subprocess
 from typing import List, Tuple
 import sys
 from icecream import ic  # type: ignore
+from enum import Enum, auto
 ic.configureOutput(outputFunction=print)
 ic.disable()
 
@@ -23,6 +24,13 @@ GIT_LOG_BASE_COMMAND = ['git',
                         '--no-color',
                         '--ignore-missing',  # Support empty repo
                         ]
+
+
+class MissingValuePolicy(Enum):
+    SILENT = auto()
+    WARN = auto()
+    FAIL = auto()
+
 
 KeyValueList = List[Tuple[str, str]]
 
@@ -418,10 +426,18 @@ def report(measurement: str,
     fig.write_html(output, include_plotlyjs='cdn')
 
 
-def filter_df(df, selector: KeyValueList):
+def filter_df(df,
+              selector: KeyValueList,
+              missing: MissingValuePolicy = MissingValuePolicy.FAIL):
     for (key, value) in selector:
         if key not in df.columns:
-            raise ValueError(f"Selector '{key}' does not exist")
+            message = f"Selector '{key}' does not exist"
+            if missing == MissingValuePolicy.SILENT:
+                continue
+            elif missing == MissingValuePolicy.WARN:
+                print(message, file=sys.stderr)
+            else:
+                raise ValueError(message)
         df = df[df[key] == value]
     return df
 
@@ -461,19 +477,9 @@ def audit(measurement: str,
     trailers = get_trailer_df()
 
     selector.append(('name', measurement))
-    # The historical data allows for non-existent filters
-    try:
-        df_tail = filter_df(df_tail, selector)
-    except ValueError as e:
-        print(e, file=sys.stderr)
-
-    # The trailers allow for silent non-existent data
-    try:
-        trailers = filter_df(trailers, selector)
-    except ValueError:
-        pass
-
-    df_head = filter_df(df_head, selector)
+    df_head = filter_df(df_head, selector, missing=MissingValuePolicy.FAIL)
+    df_tail = filter_df(df_tail, selector, missing=MissingValuePolicy.WARN)
+    trailers = filter_df(trailers, selector, missing=MissingValuePolicy.SILENT)
 
     accept_regression = len(trailers) > 0
 

--- a/test/test_perf_accept.sh
+++ b/test/test_perf_accept.sh
@@ -31,6 +31,22 @@ create_commit
 git perf add -m test 5010
 git perf audit -m test
 
+# Check when using non-existent selectors for trailers
+cd_empty_repo
+create_commit
+git perf add -m test 2 -kv os=ubuntu
+create_commit
+git perf add -m test 3 -kv os=ubuntu
+create_commit
+git perf add -m test 10 -kv os=ubuntu
+git perf audit -m test -s os=ubuntu && exit 1
+git perf good -m someother
+# This can fail is filtering with "os" on the trailers without any kvs
+# is done incorrectly.
+git perf audit -m test -s os=ubuntu && exit 1
+git perf good -m test
+git perf audit -m test -s os=ubuntu
+
 # Check perf-accept functionality (base case)
 # Only accept performance regressions if non-merge HEAD commit has corresponding trailer
 cd_empty_repo


### PR DESCRIPTION
Sometimes git trailers have a missing selector which is nonetheless
specified. As this should fail silently, we cannot try/except but must
instead continue and skip the selector. Otherwise, no filtering will
take place...