### PR TITLE
fix: ensure consistent ordering in legend

### DIFF
--- a/src/git_perf/git_perf.py
+++ b/src/git_perf/git_perf.py
@@ -408,6 +408,7 @@ def report(measurement: str,
                   "not found in columns", file=sys.stderr)
             sys.exit(1)
         args['color'] = separate_by
+        args['category_orders'] = {separate_by: df[separate_by].unique()}
 
     if (len(df) == 0):
         print("No performance measurements after filtering found", file=sys.stderr)


### PR DESCRIPTION
When printing multiple separate figures their dataframes might
encounter the "color" / "separate-by" argument in different orders.
This leads to inconsistent ordering and coloring. That in turns makes
comparison of values across multiple, separate graphs difficult.

This change determines the category_orders once and uses this
consistently across the separate figures.