### PR TITLE
feat: pass audit if there are too few measurements

### DIFF
--- a/src/git_perf/git_perf.py
+++ b/src/git_perf/git_perf.py
@@ -6,7 +6,7 @@
 import argparse
 import time
 import subprocess
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import sys
 from icecream import ic  # type: ignore
 from enum import Enum, auto
@@ -150,6 +150,12 @@ audit_parser.add_argument(
     help='Limit to the number of commits considered',
     type=int,
     default=DEFAULT_MAX_COUNT)
+audit_parser.add_argument(
+    '-min',
+    '--min-measurements',
+    help='Minimum number of measurements needed. If less, pass test and assume '
+         'more measurements are needed.',
+    type=int)
 audit_parser.add_argument(
     '-g',
     '--group-by',
@@ -449,9 +455,12 @@ def filter_df(df,
     return df
 
 
-def summarize(df, group_by: str, aggregate_by: str) -> Tuple[float, float]:
+def summarize(df,
+              group_by: str,
+              aggregate_by: str,
+              min_measurements: Optional[int] = None) -> Tuple[float, float]:
     import numpy as np
-    if (len(df) == 0):
+    if (len(df) == 0 or (min_measurements is not None and len(df) < min_measurements)):
         return (np.nan, np.nan)
     group = df.groupby(group_by).val.agg(aggregate_by)
     return (group.mean(), group.std())
@@ -462,6 +471,8 @@ def audit(measurement: str,
           group_by: str,
           aggregate_by: str,
           selector: KeyValueList,
+          # TODO(kaihowl) inconsistent with `n` argument (not counting HEAD vs counting HEAD)
+          min_measurements: Optional[int],
           sigma: float):
     import numpy as np
 
@@ -493,7 +504,7 @@ def audit(measurement: str,
     ic(df_head.to_markdown())
     ic(df_tail.to_markdown())
 
-    tail_mean, tail_std = summarize(df_tail, group_by, aggregate_by)
+    tail_mean, tail_std = summarize(df_tail, group_by, aggregate_by, min_measurements)
     print(f"mean: {tail_mean}")
     print(f"std: {tail_std}")
 

--- a/test/test_audit_basic.sh
+++ b/test/test_audit_basic.sh
@@ -10,20 +10,43 @@ source "$script_dir/common.sh"
 echo Basic audit tests
 
 cd_temp_repo
+# mean: 2, std: 1
 git checkout HEAD~3
 git perf add -m timer 1
 git checkout - && git checkout HEAD~2
 git perf add -m timer 2
 git checkout - && git checkout HEAD~1
 git perf add -m timer 3
+# head commit
 git checkout -
 git perf add -m timer 4
-# mean: 2, std: 1
+# measure
 git perf audit -m timer -d 4
 git perf audit -m timer -d 3
 git perf audit -m timer -d 2
 git perf audit -m timer -d 1.9999 && exit 1
 git perf audit -m timer -d 1 && exit 1
+
+
+echo Initial measurements with too few data points
+cd_empty_repo
+# mean: 15, std: 5
+create_commit
+git perf add -m timer 10
+create_commit
+git perf add -m timer 15
+create_commit
+git perf add -m timer 20
+# head commit
+create_commit
+git perf add -m timer 30
+# measure
+git perf audit -m timer -d 3
+git perf audit -m timer -d 2 && exit 1
+git perf audit -m timer -d 2 --min-measurements 10
+git perf audit -m timer -d 2 --min-measurements 4
+git perf audit -m timer -d 2 --min-measurements 3 && exit 1
+
 
 echo Stable measurements with zero stddev
 cd_empty_repo


### PR DESCRIPTION
In case that only a few measurements have been collected, the stddev
is not yet stable enough. Therefore, the audit should pass in those
cases.

Since the number of commits passed by `-n` only determines the
look-behind of commits scanned, and those commits are not guaranteed to
all have measurements, a second parameter --min-measurements is added.