### PR TITLE
chore: bump report measurement epoch

### DIFF
--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -1,1 +1,1 @@
-measurement = { report-size = { epoch = "c25d7d4b" } }
+measurement = { report-size = { epoch = "c25d7d4b" } , report = { epoch = "cfe69917" } }


### PR DESCRIPTION
With cfe69917 we should have bumped the epoch for report as well.