### PR TITLE
fix: report size changed independent of changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,15 @@ jobs:
           git perf audit -n 40 -m report -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 10
           git perf audit -n 40 -m report-size -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 10
 
+    - name: Archive report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        include-hidden-files: true
+        name: report-${{matrix.os}}-${{matrix.rust}}.html
+        path: report.html
+        if-no-files-found: error
+
 
   rustfmt:
     name: rustfmt

--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -1,1 +1,1 @@
-measurement = { report-size = { epoch = "c25d7d4b" } , report = { epoch = "cfe69917" } }
+measurement = { report-size = { epoch = "f3709134" } , report = { epoch = "cfe69917" } , test-measure2 = { epoch = "b5f56987" } }


### PR DESCRIPTION
Before: 1,787.000
After: 1,787.000

Cannot reconstruct the old report size and will except the new size without further investigation.