### PR TITLE
ci: run with a separate concurrency token for each branch for reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,3 +138,4 @@ jobs:
     # TODO(kaihowl) run with version from branch instead?
     with:
       additional-args: '-s rust'
+      concurrency-token: gh-pages-${{ github.ref }}


### PR DESCRIPTION
topic:ci-run-with-a-separate-concurrency-token-for-each-branch-for-reporting