### PR TITLE
ci: allow concurrency again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,7 @@ jobs:
     - uses: fregante/setup-git-user@v2
 
     - name: Run tests
-      # TODO(kaihowl) allow concurrency after test rewrite for cwd again
-      run: ${{ env.CARGO }} test --verbose ${{ env.TARGET_FLAGS }} -- --test-threads 1
+      run: ${{ env.CARGO }} test --verbose ${{ env.TARGET_FLAGS }}
 
     - name: Run bash e2e tests
       run: |


### PR DESCRIPTION
The problematic tests themselves prohibit concurrent execution.
Therefore, we don't need to enforce that on this level anymore.

topic:ci-allow-concurrency-again