### PR TITLE
fix: setup git user explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
       with:
         fetch-depth: 40
 
+    - name: Setup git user
+      uses: fregante/setup-git-user@v1
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:


### PR DESCRIPTION
This is necessary for tests like
`git_interop::test::test_customheader_push stdout`.

topic:fix-setup-git-user-explicitly