### PR TITLE
test: manual setup of git user name and email

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,10 @@ jobs:
       with:
         fetch-depth: 40
 
-    - name: Setup git user
-      uses: fregante/setup-git-user@v2
+    - name: Set Git user and email
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "actions@github.com"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
@@ -76,8 +78,6 @@ jobs:
 
     - name: Build git-perf
       run: ${{ env.CARGO }} build --verbose ${{ env.TARGET_FLAGS }}
-
-    - uses: fregante/setup-git-user@v2
 
     - name: Run tests
       run: ${{ env.CARGO }} test --verbose ${{ env.TARGET_FLAGS }}


### PR DESCRIPTION
Ditch the fregante/setup-git-user due to too much cleverness and
failure to set up to a valid but fake user name.

Fixes: #144

topic:test-remove-duplicate-setup-git-user-action