### PR TITLE
refactor: remove TODO comment and add epoch parsing tests

### DIFF
--- a/git_perf/src/data.rs
+++ b/git_perf/src/data.rs
@@ -17,7 +17,6 @@ pub struct MeasurementData {
     pub epoch: u32,
     pub name: String,
     pub timestamp: f64,
-    // TODO(kaihowl) check size of type
     pub val: f64,
     pub key_values: HashMap<String, String>,
 }

--- a/git_perf/src/serialization.rs
+++ b/git_perf/src/serialization.rs
@@ -50,7 +50,6 @@ fn deserialize_single(line: &str) -> Option<MeasurementData> {
         return None;
     }
 
-    // TODO(kaihowl) test this
     let epoch = components[0];
     let epoch = match epoch.parse::<u32>() {
         Ok(e) => e,
@@ -180,5 +179,24 @@ mod test {
         };
         let serialized = serialize_single(&md, DELIMITER);
         assert_eq!(serialized, "3Mymeasurement1234567.042.0mykey=myvalue\n");
+    }
+
+    #[test]
+    fn test_epoch_parsing() {
+        // Test valid epoch
+        let valid_line = "42test1234123";
+        let result = deserialize_single(valid_line);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().epoch, 42);
+
+        // Test invalid epoch (non-numeric)
+        let invalid_line = "not_a_numbertest1234123";
+        let result = deserialize_single(invalid_line);
+        assert!(result.is_none());
+
+        // Test invalid epoch (out of range)
+        let out_of_range_line = "4294967296test1234123"; // u32::MAX + 1
+        let result = deserialize_single(out_of_range_line);
+        assert!(result.is_none());
     }
 }


### PR DESCRIPTION
- Removed a TODO comment regarding type size check in MeasurementData struct.
- Added unit tests for epoch parsing in serialization, covering valid and invalid cases.

topic: refactor-remove-todo-comment-and-add-epoch-parsing-tests