### PR TITLE
refactor: remove TODO comment in deserialize_single function

### DIFF
--- a/git_perf/src/serialization.rs
+++ b/git_perf/src/serialization.rs
@@ -50,7 +50,6 @@ fn deserialize_single(line: &str) -> Option<MeasurementData> {
         return None;
     }
 
-    // TODO(kaihowl) test this
     let epoch = components[0];
     let epoch = match epoch.parse::<u32>() {
         Ok(e) => e,


### PR DESCRIPTION
- Eliminated a TODO comment related to testing in the deserialize_single function for clarity and improved code quality.

topic:refactor-remove-todo-comment-in-deserializesingle-function