### PR TITLE
refactor: remove commented-out TODO in deserialize_single function

### DIFF
--- a/git_perf/src/serialization.rs
+++ b/git_perf/src/serialization.rs
@@ -84,7 +84,6 @@ fn deserialize_single(line: &str) -> Option<MeasurementData> {
 
     if components.len() > 4 {
         for kv in components.iter().skip(4) {
-            // TODO(kaihowl) different delimiter?
             if let Some((key, value)) = kv.split_once('=') {
                 let entry = key_values.entry(key.to_string());
                 let value = value.to_string();


### PR DESCRIPTION
- Deleted a TODO comment regarding the delimiter in the deserialize_single function to enhance code clarity and maintainability.

topic:refactor-remove-commented-out-todo-in-deserializesingle-function