### PR TITLE
refactor: remove outdated TODO comments in measurement storage

### DIFF
--- a/git_perf/src/measurement_storage.rs
+++ b/git_perf/src/measurement_storage.rs
@@ -47,8 +47,6 @@ pub fn add_multiple(
 }
 
 pub fn add(measurement: &str, value: f64, key_values: &[(String, String)]) -> Result<()> {
-    // TODO(kaihowl) configure path
-    // TODO(kaihowl) configure
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("TODO(kaihowl)");


### PR DESCRIPTION
- Eliminated TODO comments related to path configuration in the `add` function to improve code clarity and maintainability.

topic:ai-outdated-todo