### PR TITLE
ci: add clippy linting step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,20 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all --check
 
+  clippy:
+    name: clippy
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        components: clippy
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
+
   rustdoc:
     name: rust doc
     runs-on: ubuntu-22.04


### PR DESCRIPTION
- Introduced a new job in the CI workflow to run clippy for linting Rust code, ensuring code quality by treating warnings as errors.
- Configured the job to run on Ubuntu 22.04 and included steps for checking out the repository and installing the Rust toolchain with clippy.

topic:ci-add-clippy-linting-step