### PR TITLE
refactor: remove outdated TODO comment in audit function

### DIFF
--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -55,7 +55,6 @@ pub fn audit(
     }
 
     if head_summary.significantly_different_from(&tail_summary, sigma) {
-        // TODO(kaihowl) print details
         bail!(
             "HEAD differs significantly from tail measurements.\nHead: {}\nTail: {}",
             &head_summary,


### PR DESCRIPTION
- Removed a TODO comment related to printing details in the audit function to improve code clarity and maintainability.

topic:remove-todo-old