### PR TITLE
refactor: add documentation for performance measurement constants in git_interop.rs

### DIFF
--- a/git_perf/src/git_interop.rs
+++ b/git_perf/src/git_interop.rs
@@ -124,15 +124,31 @@ fn feed_git_command(
     }
 }
 
-// TODO(kaihowl) missing docs
+/// The main branch where performance measurements are stored as git notes
 const REFS_NOTES_BRANCH: &str = "refs/notes/perf-v3";
+
+/// Symbolic reference that points to the current write target for performance measurements
 const REFS_NOTES_WRITE_SYMBOLIC_REF: &str = "refs/notes/perf-v3-write";
+
+/// Prefix for temporary write target references used during concurrent operations
 const REFS_NOTES_WRITE_TARGET_PREFIX: &str = "refs/notes/perf-v3-write-";
+
+/// Prefix for temporary references used when adding new measurements
 const REFS_NOTES_ADD_TARGET_PREFIX: &str = "refs/notes/perf-v3-add-";
+
+/// Prefix for temporary references used when rewriting existing measurements
 const REFS_NOTES_REWRITE_TARGET_PREFIX: &str = "refs/notes/perf-v3-rewrite-";
+
+/// Prefix for temporary references used during merge operations
 const REFS_NOTES_MERGE_BRANCH_PREFIX: &str = "refs/notes/perf-v3-merge-";
+
+/// Branch used for reconciling and then reading performance measurements
 const REFS_NOTES_READ_BRANCH: &str = "refs/notes/perf-v3-read";
+
+/// The default remote name used for git-perf operations
 const GIT_PERF_REMOTE: &str = "git-perf-origin";
+
+/// The standard git remote name
 const GIT_ORIGIN: &str = "origin";
 
 fn map_git_error_for_backoff(e: GitError) -> ::backoff::Error<GitError> {


### PR DESCRIPTION
- Introduced documentation comments for various constants related to performance measurements, enhancing code clarity and maintainability.
- Constants documented include REFS_NOTES_BRANCH, REFS_NOTES_WRITE_SYMBOLIC_REF, and others related to temporary references and branches.

topic:refactor-add-docs-performance-measurement-constants