### PR TITLE
refactor: enhance measurement retrieval with epoch filtering

### DIFF
--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -26,7 +26,11 @@ pub fn audit(
                 .all(|s| m.key_values.get(&s.0).map(|v| *v == s.1).unwrap_or(false))
     };
 
-    let mut aggregates = summarize_measurements(all, &summarize_by, &filter_by);
+    let mut aggregates = measurement_retrieval::take_while_same_epoch(summarize_measurements(
+        all,
+        &summarize_by,
+        &filter_by,
+    ));
 
     let head = aggregates
         .next()

--- a/git_perf/src/measurement_retrieval.rs
+++ b/git_perf/src/measurement_retrieval.rs
@@ -21,7 +21,7 @@ pub fn summarize_measurements<'a, F>(
 where
     F: Fn(&MeasurementData) -> bool,
 {
-    let measurements = commits.map(move |c| {
+    commits.map(move |c| {
         c.map(|c| {
             let measurement = c
                 .measurements
@@ -34,12 +34,16 @@ where
                 measurement,
             }
         })
-    });
+    })
+}
 
-    let mut first_epoch = None;
-
-    // TODO(kaihowl) this is a second responsibility, move out? "EpochClearing"
-    measurements.take_while(move |m| match &m {
+/// Adapter to take results while the epoch is the same as the first one encountered.
+pub fn take_while_same_epoch<I>(iter: I) -> impl Iterator<Item = Result<CommitSummary>>
+where
+    I: Iterator<Item = Result<CommitSummary>>,
+{
+    let mut first_epoch: Option<u32> = None;
+    iter.take_while(move |m| match m {
         Ok(CommitSummary {
             measurement: Some(m),
             ..


### PR DESCRIPTION
- Updated the `audit` function to utilize `take_while_same_epoch` for improved measurement aggregation based on the same epoch.
- Introduced `take_while_same_epoch` function in `measurement_retrieval.rs` to filter results while the epoch remains consistent, enhancing clarity and functionality.

topic:refactor-enhance-measurement-retrieval