### PR TITLE
docs: clean up and clarify outdated TODOs

### DIFF
--- a/git_perf/src/measurement_retrieval.rs
+++ b/git_perf/src/measurement_retrieval.rs
@@ -83,7 +83,8 @@ pub struct Commit {
     pub measurements: Vec<MeasurementData>,
 }
 
-// TODO(hoewelmk) copies all measurements, expensive...
+// Copying all measurements is currently necessary due to deserialization from git notes.
+// Optimizing this would require a change in the storage or deserialization model.
 pub fn walk_commits(num_commits: usize) -> Result<impl Iterator<Item = Result<Commit>>> {
     let vec = git_interop::walk_commits(num_commits)?;
     Ok(vec
@@ -97,7 +98,4 @@ pub fn walk_commits(num_commits: usize) -> Result<impl Iterator<Item = Result<Co
             })
         }))
     // When this fails it is due to a shallow clone.
-    // TODO(kaihowl) proper shallow clone support
-    // https://github.com/libgit2/libgit2/issues/3058 tracks that we fail to revwalk the
-    // last commit because the parent cannot be loooked up.
 }


### PR DESCRIPTION
- we are not using libgit anymore
- shallow clone support is added
- copying of measurements is necessary and a bigger refactor to support
  generators etc. is not necessary.

topic:kaihowlstack-docs-clean-up-and-clarify-outdated-todos