### PR TITLE
refactor: rename ReductionFuncIterator to MeasurementReducer for clarity

### DIFF
--- a/git_perf/src/measurement_retrieval.rs
+++ b/git_perf/src/measurement_retrieval.rs
@@ -9,7 +9,7 @@ use cli_types::ReductionFunc;
 use anyhow::Result;
 
 // TODO(kaihowl) oh god naming
-pub trait ReductionFuncIterator<'a>: Iterator<Item = &'a MeasurementData> {
+pub trait MeasurementReducer<'a>: Iterator<Item = &'a MeasurementData> {
     fn reduce_by(self, fun: ReductionFunc) -> Option<MeasurementSummary>;
 }
 
@@ -56,7 +56,7 @@ where
     })
 }
 
-impl<'a, T> ReductionFuncIterator<'a> for T
+impl<'a, T> MeasurementReducer<'a> for T
 where
     T: Iterator<Item = &'a MeasurementData>,
 {

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -16,7 +16,7 @@ use plotly::{
 // TODO(kaihowl) find central place for the data structures
 use crate::{
     data::{MeasurementData, MeasurementSummary},
-    measurement_retrieval::{self, Commit, ReductionFuncIterator},
+    measurement_retrieval::{self, Commit, MeasurementReducer},
     serialization::{serialize_single, DELIMITER},
 };
 use cli_types::ReductionFunc;


### PR DESCRIPTION
- Updated the trait name from `ReductionFuncIterator` to `MeasurementReducer` to better reflect its purpose.
- Adjusted the implementation and usage in `measurement_retrieval.rs` and `reporting.rs` accordingly.

topic:kaihowlstack-refactor-rename-reductionfunciterator-to-measurementreducer-for-clarity