### PR TITLE
test: add validation for git perf prune outside a repository

### DIFF
--- a/test/test_prune.sh
+++ b/test/test_prune.sh
@@ -40,6 +40,16 @@ if [[ ${output} != *'shallow'* ]]; then
 fi
 popd
 
+# Test running git perf prune outside of a git repository
+pushd "$(mktemp -d)"
+output=$(git perf prune 2>&1 1>/dev/null) && exit 1
+if [[ $output != *'not a git repository'* && $output != *'fatal'* ]]; then
+  echo "Expected error for running outside a git repo, got:"
+  echo "$output"
+  exit 1
+fi
+popd
+
 # Normal operations on main repo
 pushd "$(mktemp -d)"
 git init


### PR DESCRIPTION
- Implemented a test in `test_prune.sh` to ensure that running `git perf prune` outside of a git repository correctly returns an error message indicating the absence of a repository.
- This enhances error handling and provides better feedback for users attempting to run the command in an invalid context.

topic:empty-repo-prune