### PR TITLE
refactor: remove outdated TODO comment in raw_add_note_line_to_head

### DIFF
--- a/git_perf/src/git_interop.rs
+++ b/git_perf/src/git_interop.rs
@@ -238,7 +238,6 @@ fn raw_add_note_line_to_head(line: &str) -> Result<(), GitError> {
     )?;
 
     // Update current write branch with pending write
-    // TODO(kaihowl) duplication
     git_update_ref(unindent(
         format!(
             r#"


### PR DESCRIPTION
- Eliminated a TODO comment regarding duplication in the `raw_add_note_line_to_head` function to improve code clarity and maintainability.

topic:refactor-remove-outdated-todo