### PR TITLE
refactor: remove outdated TODO comments in new_symbolic_write_ref

### DIFF
--- a/git_perf/src/git_interop.rs
+++ b/git_perf/src/git_interop.rs
@@ -617,11 +617,6 @@ fn new_symbolic_write_ref() -> Result<String, GitError> {
     let suffix = random_suffix();
     let target = format!("{REFS_NOTES_WRITE_TARGET_PREFIX}{suffix}");
 
-    // TODO(kaihowl) can this actually return a failure upon abort?
-    // TODO(kaihowl) does this actually run atomically as it claims?
-    // See https://github.com/libgit2/libgit2/issues/5918 for a counter example
-    // Also source code for the refs/files-backend.c does not look up to the task?
-    // Do we need packed references after all? Or the new reftable format?
     git_update_ref(unindent(
         format!(
             r#"


### PR DESCRIPTION
Based on perusing the code in https://github.com/git/git/blob/master/refs.h#L865-L869, I concluded that git-update-ref provides the expected atomicity guarantees.

topic:refactor-remove-outdated-todo-comments