### PR TITLE
refactor: enhance read_config_from_file function signature

### DIFF
--- a/git_perf/src/config.rs
+++ b/git_perf/src/config.rs
@@ -18,8 +18,9 @@ pub fn read_config() -> Result<String> {
     read_config_from_file(".gitperfconfig")
 }
 
-// TODO(kaihowl) proper file type
-fn read_config_from_file(file: &str) -> Result<String> {
+use std::path::Path;
+
+fn read_config_from_file<P: AsRef<Path>>(file: P) -> Result<String> {
     let mut conf_str = String::new();
     File::open(file)?.read_to_string(&mut conf_str)?;
     Ok(conf_str)


### PR DESCRIPTION
- Updated the `read_config_from_file` function to accept a generic path type, improving flexibility and allowing for better integration with various path representations.
- Removed outdated TODO comment regarding file type, enhancing code clarity.

topic:refactor-enhance-read-config-function-signature