### PR TITLE
refactor: remove outdated TODO comment in raw_push function

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -559,8 +559,6 @@ fn raw_push(work_dir: Option<&Path>) -> Result<(), GitError> {
     git_update_ref(commands)?;
 
     Ok(())
-
-    // TODO(kaihowl) - Clean up all local write refs that have been merged into the upstream branch.
 }
 
 fn git_push_notes_ref(


### PR DESCRIPTION
- Eliminated a TODO comment regarding the cleanup of local write refs that have been merged into the upstream branch, enhancing code clarity and maintainability.

topic:stack_refactor-remove-outdated-todo-comment-raw-push