### PR TITLE
fix: clean up badly reviewed, cursor-generated PR fallout

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -49,7 +49,6 @@ fn map_git_error_for_backoff(e: GitError) -> ::backoff::Error<GitError> {
         | GitError::MissingHead { .. }
         | GitError::NoRemoteMeasurements { .. }
         | GitError::NoUpstream { .. }
-        | GitError::EmptyOrNeverPushedRemote { .. }
         | GitError::MissingMeasurements => ::backoff::Error::permanent(e),
     }
 }
@@ -317,13 +316,7 @@ fn raw_remove_measurements_from_commits(older_than: DateTime<Utc>) -> Result<(),
     // 4. try to push
     fetch(None)?;
 
-    let current_notes_head = match git_rev_parse(REFS_NOTES_BRANCH) {
-        Ok(head) => head,
-        Err(GitError::MissingHead { .. }) => {
-            return Err(GitError::EmptyOrNeverPushedRemote {});
-        }
-        Err(e) => return Err(e),
-    };
+    let current_notes_head = git_rev_parse(REFS_NOTES_BRANCH)?;
 
     let target = create_temp_rewrite_head(&current_notes_head)?;
 
@@ -1007,14 +1000,12 @@ mod test {
         init_repo(tempdir.path());
         set_current_dir(tempdir.path()).expect("Failed to change dir");
         // Add a dummy remote so the code can check for empty remote
-        run_git_command(
-            &["remote", "add", "origin", "https://example.com/empty.git"],
-            tempdir.path(),
-        );
+        let git_dir_url = format!("file://{}", tempdir.path().display());
+        run_git_command(&["remote", "add", "origin", &git_dir_url], tempdir.path());
         // Do not add any notes/measurements or push anything
         let result = super::raw_remove_measurements_from_commits(Utc::now());
         match result {
-            Err(GitError::EmptyOrNeverPushedRemote { .. }) => {}
+            Err(GitError::NoRemoteMeasurements { .. }) => {}
             other => panic!("Expected EmptyOrNeverPushedRemote error, got: {:?}", other),
         }
     }

--- a/git_perf/src/git/git_lowlevel.rs
+++ b/git_perf/src/git/git_lowlevel.rs
@@ -92,11 +92,6 @@ pub(super) fn map_git_error(err: GitError) -> GitError {
         GitError::ExecError { command: _, output } if output.stderr.contains("find remote ref") => {
             GitError::NoRemoteMeasurements {}
         }
-        GitError::ExecError { command: _, output }
-            if output.stderr.contains("repository") && output.stderr.contains("not found") =>
-        {
-            GitError::EmptyOrNeverPushedRemote {}
-        }
         _ => err,
     }
 }

--- a/git_perf/src/git/git_types.rs
+++ b/git_perf/src/git/git_types.rs
@@ -31,14 +31,11 @@ pub(super) enum GitError {
     #[error("Git failed to execute.\n\nstdout:\n{0}\nstderr:\n{1}", output.stdout, output.stderr)]
     ExecError { command: String, output: GitOutput },
 
-    #[error("No measurements found on remote")]
+    #[error("Remote repository is empty or has never been pushed to. Please push some measurements first.")]
     NoRemoteMeasurements {},
 
     #[error("No upstream found. Consider setting origin or {}.", GIT_PERF_REMOTE)]
     NoUpstream {},
-
-    #[error("Remote repository is empty or has never been pushed to. Please push some measurements first.")]
-    EmptyOrNeverPushedRemote {},
 
     #[error("Failed to execute git command")]
     IoError(#[from] io::Error),

--- a/test/test_pull_messages.sh
+++ b/test/test_pull_messages.sh
@@ -41,8 +41,8 @@ git push
 
 # TODO(kaihowl) move functionality for check for output in common function
 output="$(git perf pull 2>&1 1>/dev/null)" && exit 1
-if [[ $output != *'No measurements found on remote'* ]]; then
-  echo "Missing 'No measurements found on remote' in output:"
+if [[ $output != *'Remote repository is empty or has never been pushed to'* ]]; then
+  echo "Missing 'Remote repository is empty or has never been pushed to' in output:"
   echo "$output"
   exit 1
 fi


### PR DESCRIPTION
The call for a better error message in case of no measurements on the
remote, was fixed by cursor by adding a completely new error case. This
was unnecessary. There was a perfectly fine error case available.
Moreover, the matching of the error message was incorrect for the new
case: This was due to cursor trying to fix a test case by changing the
production incorrectly.

topic:kaihowlstack_fix-clean-up-badly-reviewed-cursor-generated-pr-fallout