### PR TITLE
fix: use proper origin for git-perf

### DIFF
--- a/git_perf/src/git/git_lowlevel.rs
+++ b/git_perf/src/git/git_lowlevel.rs
@@ -90,7 +90,7 @@ pub(super) fn map_git_error(err: GitError) -> GitError {
             GitError::RefConcurrentModification { output }
         }
         GitError::ExecError { command: _, output } if output.stderr.contains("find remote ref") => {
-            GitError::NoRemoteMeasurements {}
+            GitError::NoRemoteMeasurements { output }
         }
         _ => err,
     }

--- a/git_perf/src/git/git_types.rs
+++ b/git_perf/src/git/git_types.rs
@@ -31,8 +31,8 @@ pub(super) enum GitError {
     #[error("Git failed to execute.\n\nstdout:\n{0}\nstderr:\n{1}", output.stdout, output.stderr)]
     ExecError { command: String, output: GitOutput },
 
-    #[error("Remote repository is empty or has never been pushed to. Please push some measurements first.")]
-    NoRemoteMeasurements {},
+    #[error("Remote repository is empty or has never been pushed to. Please push some measurements first.\n{0}\n{1}", output.stdout, output.stderr)]
+    NoRemoteMeasurements { output: GitOutput },
 
     #[error("No upstream found. Consider setting origin or {}.", GIT_PERF_REMOTE)]
     NoUpstream {},


### PR DESCRIPTION
Do not use `origin`. Use the correct git-perf specific origin instead.

topic:kaihowlstack_fix-use-proper-origin-for-git-perf