### PR TITLE
doc: add TODOs for documentation and config improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ metrics in a single central location.
 ## Migrate measurements
 TODO document this
 
+# Setup Different Remote
+TODO document this
+
 # Docs
 
 See [manpages](./docs/manpage.md).

--- a/git_perf/src/config.rs
+++ b/git_perf/src/config.rs
@@ -13,7 +13,6 @@ pub fn write_config(conf: &str) -> Result<()> {
     Ok(())
 }
 
-// TODO(kaihowl) hierachy of config files?
 pub fn read_config() -> Result<String> {
     read_config_from_file(".gitperfconfig")
 }
@@ -34,7 +33,6 @@ pub fn determine_epoch_from_config(measurement: &str) -> Option<u32> {
 }
 
 fn determine_epoch(measurement: &str, conf_str: &str) -> Option<u32> {
-    // TODO(kaihowl) buffered reading?
     let config = conf_str
         .parse::<Document>()
         .expect("Failed to parse config");

--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -559,7 +559,6 @@ fn git_push_notes_ref(
     push_ref: &str,
     working_dir: &Option<&Path>,
 ) -> Result<(), GitError> {
-    // TODO(kaihowl) configure remote?
     // - CAS push the temporary merge ref to upstream using the noted down upstream ref
     //     - In case of concurrent pushes, back off and restart fresh from previous step.
     let output = capture_git_output(

--- a/git_perf/src/measurement_retrieval.rs
+++ b/git_perf/src/measurement_retrieval.rs
@@ -8,7 +8,6 @@ use cli_types::ReductionFunc;
 
 use anyhow::Result;
 
-// TODO(kaihowl) oh god naming
 pub trait MeasurementReducer<'a>: Iterator<Item = &'a MeasurementData> {
     fn reduce_by(self, fun: ReductionFunc) -> Option<MeasurementSummary>;
 }

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -174,8 +174,6 @@ impl<'a> Reporter<'a> for CsvReporter<'a> {
     }
 
     fn as_bytes(&self) -> Vec<u8> {
-        // TODO(kaihowl) write to path directly instead?
-
         self.indexed_measurements
             .iter()
             .map(|(index, measurement_data)| {


### PR DESCRIPTION
- Added TODOs in README for documenting setup of different remote and migration of measurements.
- Removed outdated TODO comments in config and measurement retrieval files to enhance clarity.
  - Cannot do hierarchical configs as the config is version controlled as part of the repository on purpose.
- Cleaned up comments in reporting and git interop files for better maintainability.

topic:kaihowlstack_doc-add-todos-for-documentation-and-config-improvements