### PR TITLE
fix: do not use git 2.46's symref-create for broader compatibility

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -167,7 +167,7 @@ fn ensure_symbolic_write_ref_exists() -> Result<(), GitError> {
             format!(
                 r#"
                 start
-                symref-create {REFS_NOTES_WRITE_SYMBOLIC_REF} {target}
+                symref-update {REFS_NOTES_WRITE_SYMBOLIC_REF} {target} oid {EMPTY_OID}
                 commit
                 "#
             )


### PR DESCRIPTION
topic:kaihowlstack_fix-do-not-use-git-246s-symref-create-for-broader-compatibility