### PR TITLE
fix: min version needed is 2.45.0 for git

### DIFF
--- a/git_perf/src/git/git_definitions.rs
+++ b/git_perf/src/git/git_definitions.rs
@@ -1,3 +1,8 @@
+/// Min supported git version
+/// Must be version 2.45.0 at least to support symref-update commands
+/// TODO(kaihowl) check if we can get by with this version
+pub const EXPECTED_VERSION: (i32, i32, i32) = (2, 45, 0);
+
 /// The main branch where performance measurements are stored as git notes
 pub const REFS_NOTES_BRANCH: &str = "refs/notes/perf-v3";
 

--- a/git_perf/src/git/git_lowlevel.rs
+++ b/git_perf/src/git/git_lowlevel.rs
@@ -1,4 +1,7 @@
-use super::git_types::{GitError, GitOutput};
+use super::{
+    git_definitions::EXPECTED_VERSION,
+    git_types::{GitError, GitOutput},
+};
 
 use std::{
     env::current_dir,
@@ -176,12 +179,11 @@ fn concat_version(version_tuple: (i32, i32, i32)) -> String {
 
 pub fn check_git_version() -> Result<()> {
     let version_tuple = get_git_version().context("Determining compatible git version")?;
-    let expected_version = (2, 41, 0);
-    if version_tuple < expected_version {
+    if version_tuple < EXPECTED_VERSION {
         bail!(
             "Version {} is smaller than {}",
             concat_version(version_tuple),
-            concat_version(expected_version)
+            concat_version(EXPECTED_VERSION)
         )
     }
     Ok(())

--- a/test/fake_git_2.45.0/git
+++ b/test/fake_git_2.45.0/git
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [ $# == 1 ] || [ "$1" == --version ]; then
-  echo git version 2.41.0
+  echo git version 2.45.0
 fi

--- a/test/test_version.sh
+++ b/test/test_version.sh
@@ -27,7 +27,7 @@ export PATH=${script_dir}/fake_git_2.40.0:$PATH
 git-perf add -m test 12 && exit 1
 
 # Git version just right
-export PATH=${script_dir}/fake_git_2.41.0:$PATH
+export PATH=${script_dir}/fake_git_2.45.0:$PATH
 git-perf add -m test 12
 
 exit 0


### PR DESCRIPTION
topic:kaihowlstack_fix-min-version-needed-is-2450-for-git