### PR TITLE
fix: revert "do not use git 2.46's symref-create for broader compatibility (#207)"

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -14,7 +14,7 @@ jobs:
           # - "v2.34.1" # Ubuntu 22.04 LTS version
           # - "v2.35.0" # Example: A more recent, stable version
           # - "v2.40.1" # Example: Another common recent version
-          - "v2.45.0" # Example: A fairly recent version
+          - "v2.46.0" # Example: A fairly recent version
           - "v2.50.1" # Example: A very recent version
 
     steps:

--- a/git_perf/src/git/git_definitions.rs
+++ b/git_perf/src/git/git_definitions.rs
@@ -1,7 +1,7 @@
 /// Min supported git version
 /// Must be version 2.45.0 at least to support symref-update commands
 /// TODO(kaihowl) check if we can get by with this version
-pub const EXPECTED_VERSION: (i32, i32, i32) = (2, 45, 0);
+pub const EXPECTED_VERSION: (i32, i32, i32) = (2, 46, 0);
 
 /// The main branch where performance measurements are stored as git notes
 pub const REFS_NOTES_BRANCH: &str = "refs/notes/perf-v3";

--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -167,7 +167,7 @@ fn ensure_symbolic_write_ref_exists() -> Result<(), GitError> {
             format!(
                 r#"
                 start
-                symref-update {REFS_NOTES_WRITE_SYMBOLIC_REF} {target} oid {EMPTY_OID}
+                symref-create {REFS_NOTES_WRITE_SYMBOLIC_REF} {target}
                 commit
                 "#
             )

--- a/test/fake_git_2.46.0/git
+++ b/test/fake_git_2.46.0/git
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [ $# == 1 ] || [ "$1" == --version ]; then
-  echo git version 2.45.0
+  echo git version 2.46.0
 fi

--- a/test/test_version.sh
+++ b/test/test_version.sh
@@ -27,7 +27,7 @@ export PATH=${script_dir}/fake_git_2.40.0:$PATH
 git-perf add -m test 12 && exit 1
 
 # Git version just right
-export PATH=${script_dir}/fake_git_2.45.0:$PATH
+export PATH=${script_dir}/fake_git_2.46.0:$PATH
 git-perf add -m test 12
 
 exit 0


### PR DESCRIPTION
This reverts commit 408fdb9883896c55eabd4f8a9768f0fbb9bb735b.

And correctly set the min version to 2.46

topic:kaihowlstack_fix-revert-do-not-use-git-246s-symref-create-for-broader-compatibility-207