### PR TITLE
chore: remove outdated todo

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -494,7 +494,6 @@ fn consolidate_write_branches_into(
     Ok(refs)
 }
 
-//TODO(kaihowl) clean up pub methods
 fn raw_push(work_dir: Option<&Path>) -> Result<(), GitError> {
     ensure_remote_exists()?;
     // This might merge concurrently created write branches. There is no protection against that.


### PR DESCRIPTION
With the split of the git module, unnecessary pub methods had been
cleaned up already. Did not find further problems in this file.

topic:kaihowlstack_chore-remove-outdated-todo