### PR TITLE
feat: only report measurements once

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -85,10 +85,36 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             })
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
+            
+            const commentBody = `⏱  [Performance Results](${pages.data.html_url}/${REPORT_NAME}.html)`
+            
+            // Find existing performance comment
+            const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `⏱  [Performance Results](${pages.data.html_url}/${REPORT_NAME}.html)`
+              issue_number: context.issue.number,
+            })
+            
+            const existingComment = comments.data.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('⏱  [Performance Results]')
+            )
+
+            if (existingComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: commentBody
               })
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              })
+            }
 


### PR DESCRIPTION
This update modifies the GitHub Actions workflow to check for existing performance result comments on issues. If a comment exists, it updates the comment instead of creating a new one, improving clarity and reducing clutter in issue discussions.

## Preflight

- [x] comment only added once