### PR TITLE
fix: remove explicit fetch output

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -198,7 +198,6 @@ fn fetch(work_dir: Option<&Path>) -> Result<(), GitError> {
         ],
         &work_dir,
     )
-    .map(|output| print!("{}", output.stderr))
     .map_err(map_git_error)?;
 
     let ref_after = git_rev_parse(REFS_NOTES_BRANCH).ok();

--- a/test/test_pull_messages.sh
+++ b/test/test_pull_messages.sh
@@ -62,20 +62,3 @@ if [[ $output != *'Already up to date'* ]]; then
   echo "$output"
   exit 1
 fi
-
-echo "Pulling from remote with measurements should have output"
-
-cd "$root"
-git clone "$orig" repo2
-repo2=$(pwd)/repo2
-
-cd "$repo2"
-
-output="$(git perf pull 2>/dev/null)" || exit 1
-if [[ $output != *'[new ref]'* ]]; then
-  echo "Missing '[new ref]' in output:"
-  echo "$output"
-  exit 1
-fi
-
-exit 0


### PR DESCRIPTION
Without proper i18n, this output is now fixed to English due to the LANG/LANGUAGE env variables set for git commands. We have to explicitly create output for the user in this case instead of letting git output leak through.

topic: lang-fetch-handling