### PR TITLE
fix: retry on bad object

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -42,7 +42,8 @@ fn map_git_error_for_backoff(e: GitError) -> ::backoff::Error<GitError> {
     match e {
         GitError::RefFailedToPush { .. }
         | GitError::RefFailedToLock { .. }
-        | GitError::RefConcurrentModification { .. } => ::backoff::Error::transient(e),
+        | GitError::RefConcurrentModification { .. }
+        | GitError::BadObject { .. } => ::backoff::Error::transient(e),
         GitError::ExecError { .. }
         | GitError::IoError(..)
         | GitError::ShallowRepository

--- a/git_perf/src/git/git_types.rs
+++ b/git_perf/src/git/git_types.rs
@@ -37,6 +37,9 @@ pub(super) enum GitError {
     #[error("No upstream found. Consider setting origin or {}.", GIT_PERF_REMOTE)]
     NoUpstream {},
 
+    #[error("Bad object found in the remote repository:\n{0}\n{1}", output.stdout, output.stderr)]
+    BadObject { output: GitOutput },
+
     #[error("Failed to execute git command")]
     IoError(#[from] io::Error),
 }


### PR DESCRIPTION
Reading of refs (for connectivity checks) during fetch might run
concurrently with an update-ref transaction. There is no protection
against dirty reads. We simply retry on this failure.

topic:stack-retry-bad-object