### PR TITLE
fix: ad missing repository key in git_perf_cli_types

### DIFF
--- a/cli_types/Cargo.toml
+++ b/cli_types/Cargo.toml
@@ -3,6 +3,7 @@ name = "git_perf_cli_types"
 version = "0.1.0"
 edition = "2021"
 description = "Shared CLI types for git-perf"
+repository = "https://github.com/kaihowl/git-perf"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
topic:kaihowlstack_fix-ad-missing-repository-key-in-gitperfclitypes