### PR TITLE
Merge with master and regenerate docs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,40 @@
+# Cursor Instructions for Rust Project
+
+## Code Formatting
+- Always run `rustfmt` before creating any submissions or commits
+- Ensure all Rust code follows standard formatting conventions
+- Use `cargo fmt` to format the entire workspace
+
+## Testing
+- Run tests with `cargo test -- --skip slow` to exclude slow tests
+- Ensure all tests pass before submitting code
+- Use `cargo test` for full test suite when needed
+
+## Code Quality
+- Follow Rust best practices and idiomatic code patterns
+- Use `cargo clippy` for additional linting and suggestions
+- Ensure proper error handling with Result and Option types
+- Use meaningful variable and function names
+
+## Project Structure
+- This is a Rust workspace with multiple crates (cli_types, git_perf)
+- Follow workspace conventions for shared dependencies
+- Maintain proper module organization
+
+## Pre-submission Checklist
+1. Run `cargo fmt` to format code
+2. Run `cargo test -- --skip slow` to verify tests pass
+3. Run `cargo clippy` for additional code quality checks
+4. Ensure all changes compile without warnings
+
+## Commands to Run Before Submissions
+```bash
+# Format code
+cargo fmt
+
+# Run tests (excluding slow ones)
+cargo test -- --skip slow
+
+# Optional: Run clippy for additional checks
+cargo clippy
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,104 +147,41 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-    - name: Install pandoc
-      run: sudo apt-get update && sudo apt-get install -y pandoc
-    - name: Build project to generate manpages
+    - name: Check markdown is up to date
       run: |
+        # Check that the generated markdown file exists
+        if [[ ! -f "docs/manpage.md" ]]; then
+          echo "Error: Generated markdown documentation not found at docs/manpage.md"
+          exit 1
+        fi
+        
+        # Create a backup of the original file for comparison
+        cp docs/manpage.md /tmp/original_markdown.md
+        
         # Temporarily set version to 0.0.0 to avoid version-based diffs
         sed -i 's/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/version = "0.0.0"/' git_perf/Cargo.toml
         cargo build
         # Restore original version
         git checkout -- git_perf/Cargo.toml
-    - name: Check manpage is up to date
-      run: |
-        # Define expected manpage files (explicit list to avoid globbing issues)
-        expected_files=(
-          "target/man/man1/git-perf.1"
-          "target/man/man1/git-perf-add.1"
-          "target/man/man1/git-perf-audit.1"
-          "target/man/man1/git-perf-bump-epoch.1"
-          "target/man/man1/git-perf-measure.1"
-          "target/man/man1/git-perf-prune.1"
-          "target/man/man1/git-perf-pull.1"
-          "target/man/man1/git-perf-push.1"
-          "target/man/man1/git-perf-remove.1"
-          "target/man/man1/git-perf-report.1"
-        )
         
-        # Check that all expected files exist
-        missing_files=()
-        for file in "${expected_files[@]}"; do
-          if [[ ! -f "$file" ]]; then
-            missing_files+=("$file")
-          fi
-        done
-        
-        # Check for unexpected files (new subcommands that aren't in our list)
-        unexpected_files=()
-        for file in target/man/man1/git-perf*.1; do
-          if [[ -f "$file" ]]; then
-            # Check if this file is in our expected list
-            found=false
-            for expected_file in "${expected_files[@]}"; do
-              if [[ "$file" == "$expected_file" ]]; then
-                found=true
-                break
-              fi
-            done
-            if [[ "$found" == "false" ]]; then
-              unexpected_files+=("$file")
-            fi
-          fi
-        done
-        
-        # Report any issues
-        if [[ ${#missing_files[@]} -gt 0 ]]; then
-          echo "Error: Missing manpage files:"
-          printf '%s\n' "${missing_files[@]}"
-          exit 1
-        fi
-        
-        if [[ ${#unexpected_files[@]} -gt 0 ]]; then
-          echo "Error: Unexpected manpage files found (new subcommands?):"
-          printf '%s\n' "${unexpected_files[@]}"
-          echo "Please update the expected_files array in .github/workflows/ci.yml to include these new files."
-          exit 1
-        fi
-        
-        # Generate complete manpage from current build (including all subcommands)
-        for file in "${expected_files[@]}"; do
-            echo "$(basename "$file" .1)";
-            echo "================";
-            pandoc -f man -t gfm "$file";
-            echo -e "\n\n";
-        done > /tmp/generated_manpage.md
-        
-        # Compare with existing manpage
-        if ! diff -u docs/manpage.md /tmp/generated_manpage.md > /tmp/manpage.diff; then
-          echo "Error: Manpage is out of date. A patch file has been created and will be uploaded as an artifact."
+        # Compare with the newly generated version
+        if ! diff -u /tmp/original_markdown.md docs/manpage.md > /tmp/markdown.diff; then
+          echo "Error: Markdown documentation is out of date. A patch file has been created and will be uploaded as an artifact."
           echo ""
-          echo "To fix this, you can either:"
-          echo "1. Run the manpage generation command from README.md:"
-          echo "   for file in target/man/man1/git-perf.1 target/man/man1/git-perf-add.1 target/man/man1/git-perf-audit.1 target/man/man1/git-perf-bump-epoch.1 target/man/man1/git-perf-measure.1 target/man/man1/git-perf-prune.1 target/man/man1/git-perf-pull.1 target/man/man1/git-perf-push.1 target/man/man1/git-perf-remove.1 target/man/man1/git-perf-report.1; do"
-          echo "       echo \"\$(basename \"\$file\" .1)\";"
-          echo "       echo \"================\";"
-          echo "       pandoc -f man -t gfm \"\$file\";"
-          echo "       echo -e \"\\n\\n\";"
-          echo "   done > docs/manpage.md"
+          echo "To fix this, run:"
+          echo "   cargo build"
           echo ""
-          echo "2. Or apply the patch file from the CI artifacts:"
-          echo "   patch docs/manpage.md < manpage.diff"
+          echo "The markdown documentation is automatically generated during the build process using clap_markdown."
           exit 1
         fi
-        echo "Manpage is up to date ✓"
+        echo "Markdown documentation is up to date ✓"
 
-    - name: Upload manpage patch artifact
+    - name: Upload markdown patch artifact
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: manpage-patch
-        path: /tmp/manpage.diff
+        name: markdown-patch
+        path: /tmp/markdown.diff
         if-no-files-found: error
 
   report:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-markdown"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a2617956a06d4885b490697b5307ebb09fec10b088afc18c81762d848c2339"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,9 +385,9 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.16"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b5db60b3310cdb376fbeb8826e875a38080d0c61bdec0a91a3da8338948736"
+checksum = "27b4c3c54b30f0d9adcb47f25f61fcce35c4dd8916638c6b82fbd5f4fb4179e2"
 dependencies = [
  "clap",
  "roff",
@@ -790,13 +799,14 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git-perf"
-version = "0.17.2"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "average",
  "backoff",
  "chrono",
  "clap",
+ "clap-markdown",
  "clap_mangen",
  "criterion",
  "defer",
@@ -1534,9 +1544,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roff"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rustc-demangle"

--- a/README.md
+++ b/README.md
@@ -142,23 +142,18 @@ For evaluating the statistical robustness of different dispersion methods (stdde
 
 ## Manpage Generation
 
-The manpages are automatically generated during the build process using `clap_mangen`. To regenerate the documentation:
+Both manpages and markdown documentation are automatically generated during the build process using `clap_mangen` and `clap_markdown`. To regenerate the documentation:
 
 ```bash
-# Build the project to generate manpages
+# Build the project to generate both manpages and markdown documentation
 cargo build
-
-# Convert main manpage to markdown
-pandoc -f man -t gfm target/man/man1/git-perf.1 > docs/manpage.md
-
-# Or convert the main and all subcommand manpages to markdown
-for file in target/man/man1/git-perf.1 target/man/man1/git-perf-add.1 target/man/man1/git-perf-audit.1 target/man/man1/git-perf-bump-epoch.1 target/man/man1/git-perf-measure.1 target/man/man1/git-perf-prune.1 target/man/man1/git-perf-pull.1 target/man/man1/git-perf-push.1 target/man/man1/git-perf-remove.1 target/man/man1/git-perf-report.1; do
-    echo "$(basename "$file" .1)";
-    echo "================";
-    pandoc -f man -t gfm "$file";
-    echo -e "\n\n";
-done > docs/manpage.md
 ```
+
+The documentation is automatically generated during the build process:
+- Manpages are written to `target/man/man1/` directory
+- Markdown documentation is written to `docs/manpage.md`
+
+No additional steps are required. The CI automatically validates that the markdown documentation is up-to-date with the current CLI definition.
 
 # Development
 

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -1,429 +1,194 @@
-git-perf
-================
-# NAME
+# Command-Line Help for `git-perf`
 
-git-perf
+This document contains the help content for the `git-perf` command-line program.
 
-# SYNOPSIS
+**Command Overview:**
 
-**git-perf** \[**-v**|**--verbose**\]... \[**-h**|**--help**\]
-\[**-V**|**--version**\] \<*subcommands*\>
+* [`git-perf`↴](#git-perf)
+* [`git-perf measure`↴](#git-perf-measure)
+* [`git-perf add`↴](#git-perf-add)
+* [`git-perf push`↴](#git-perf-push)
+* [`git-perf pull`↴](#git-perf-pull)
+* [`git-perf report`↴](#git-perf-report)
+* [`git-perf audit`↴](#git-perf-audit)
+* [`git-perf bump-epoch`↴](#git-perf-bump-epoch)
+* [`git-perf remove`↴](#git-perf-remove)
+* [`git-perf prune`↴](#git-perf-prune)
 
-# DESCRIPTION
+## `git-perf`
 
-# OPTIONS
+**Usage:** `git-perf [OPTIONS] <COMMAND>`
 
-  - **-v**, **--verbose**  
-    Increase verbosity level (can be specified multiple times.) The
-    first level sets level "info", second sets level "debug", and third
-    sets level "trace" for the logger
+###### **Subcommands:**
 
-  - **-h**, **--help**  
-    Print help
+* `measure` — Measure the runtime of the supplied command (in nanoseconds)
+* `add` — Add single measurement
+* `push` — Publish performance results to remote
+* `pull` — Pull performance results from remote
+* `report` — Create an HTML performance report
+* `audit` — For given measurements, check perfomance deviations of the HEAD commit against `<n>` previous commits. Group previous results and aggregate their results before comparison
+* `bump-epoch` — Accept HEAD commit's measurement for audit, even if outside of range. This is allows to accept expected performance changes. This is accomplished by starting a new epoch for the given measurement. The epoch is configured in the git perf config file. A change to the epoch therefore has to be committed and will result in a new HEAD for which new measurements have to be taken
+* `remove` — Remove all performance measurements for commits that have been committed before the specified time period
+* `prune` — Remove all performance measurements for non-existent/unreachable objects. Will refuse to work if run on a shallow clone
 
-  - **-V**, **--version**  
-    Print version
+###### **Options:**
 
-# SUBCOMMANDS
+* `-v`, `--verbose` — Increase verbosity level (can be specified multiple times.) The first level sets level "info", second sets level "debug", and third sets level "trace" for the logger
 
-  - git-perf-measure(1)  
-    Measure the runtime of the supplied command (in nanoseconds)
 
-  - git-perf-add(1)  
-    Add single measurement
 
-  - git-perf-push(1)  
-    Publish performance results to remote
-
-  - git-perf-pull(1)  
-    Pull performance results from remote
-
-  - git-perf-report(1)  
-    Create an HTML performance report
-
-  - git-perf-audit(1)  
-    For given measurements, check perfomance deviations of the HEAD
-    commit against \`\<n\>\` previous commits. Group previous results
-    and aggregate their results before comparison
-
-  - git-perf-bump-epoch(1)  
-    Accept HEAD commits measurement for audit, even if outside of range.
-    This is allows to accept expected performance changes. This is
-    accomplished by starting a new epoch for the given measurement. The
-    epoch is configured in the git perf config file. A change to the
-    epoch therefore has to be committed and will result in a new HEAD
-    for which new measurements have to be taken
-
-  - git-perf-remove(1)  
-    Remove all performance measurements for commits that have been
-    committed before the specified time period
-
-  - git-perf-prune(1)  
-    Remove all performance measurements for non-existent/unreachable
-    objects. Will refuse to work if run on a shallow clone
-
-  - git-perf-help(1)  
-    Print this message or the help of the given subcommand(s)
-
-# VERSION
-
-v0.0.0
-
-
-
-git-perf-add
-================
-# NAME
-
-add - Add single measurement
-
-# SYNOPSIS
-
-**add** \<**-m**|**--measurement**\> \[**-k**|**--key-value**\]
-\[**-h**|**--help**\] \<*VALUE*\>
-
-# DESCRIPTION
-
-Add single measurement
-
-# OPTIONS
-
-  - **-m**, **--measurement**=*NAME*  
-    Name of the measurement
-
-  - **-k**, **--key-value**=*KEY\_VALUE*  
-    Key-value pairs separated by =
-
-  - **-h**, **--help**  
-    Print help
-
-  - \<*VALUE*\>  
-    Measured value to be added
-
-
-
-git-perf-audit
-================
-# NAME
-
-audit - For given measurements, check perfomance deviations of the HEAD
-commit against \`\<n\>\` previous commits. Group previous results and
-aggregate their results before comparison
-
-# SYNOPSIS
-
-**audit** \<**-m**|**--measurement**\> \[**-n**|**--max-count**\]
-\[**-s**|**--selectors**\] \[**--min-measurements**\]
-\[**-a**|**--aggregate-by**\] \[**-d**|**--sigma**\]
-\[**-D**|**--dispersion-method**\] \[**-h**|**--help**\]
-
-# DESCRIPTION
-
-For given measurements, check perfomance deviations of the HEAD commit
-against \`\<n\>\` previous commits. Group previous results and aggregate
-their results before comparison.
-
-The audit can be configured to ignore statistically significant
-deviations if they are below a minimum relative deviation threshold.
-This helps filter out noise while still catching meaningful performance
-changes.
-
-## Statistical Dispersion Methods
-
-The audit supports two methods for calculating statistical dispersion:
-
-**Standard Deviation (stddev)**: Traditional method that is sensitive to
-outliers. Use when your performance data is normally distributed and you
-want to detect all performance changes, including those caused by outliers.
-
-**Median Absolute Deviation (MAD)**: Robust method that is less sensitive
-to outliers. Use when your performance data has occasional outliers or
-spikes, or when you want to focus on typical performance changes rather
-than extreme values.
-
-## Configuration
-
-Configuration is done via the \`.gitperfconfig\` file:
-
-**Global settings:**
-\`\[audit.global\].min\_relative\_deviation = 5.0\`
-\`\[audit.global\].dispersion\_method = "mad"\`
-
-**Measurement-specific settings (overrides global):**
-\`\[audit.measurement."name"\].min\_relative\_deviation = 10.0\`
-\`\[audit.measurement."name"\].dispersion\_method = "stddev"\`
-
-## Precedence
-
-The dispersion method is determined in this order:
-1. CLI option (\`--dispersion-method\` or \`-D\`) - highest priority
-2. Measurement-specific config - overrides global
-3. Global config - overrides default
-4. Default (stddev) - lowest priority
-
-When the relative deviation is below the threshold, the audit passes
-even if the z-score exceeds the sigma threshold. The relative deviation
-is calculated as: \`|(head\_value / tail\_median - 1.0) \* 100%|\` where
-tail\_median is the median of historical measurements (excluding HEAD).
-
-The sparkline visualization shows the range of measurements relative to
-the tail median (historical measurements only).
-
-# OPTIONS
-
-  - **-m**, **--measurement**=*MEASUREMENT*  
-
-<!-- end list -->
-
-  - **-n**, **--max-count**=*MAX\_COUNT* \[default: 40\]  
-    Limit the number of previous commits considered. HEAD is included in
-    this count
-
-  - **-s**, **--selectors**=*SELECTORS*  
-    Key-value pair separated by "=" with no whitespaces to subselect
-    measurements
-
-  - **--min-measurements**=*MIN\_MEASUREMENTS* \[default: 2\]  
-    Minimum number of measurements needed. If less, pass test and assume
-    more measurements are needed. A minimum of two historic measurements
-    are needed for proper evaluation of standard deviation
-
-  - **-a**, **--aggregate-by**=*AGGREGATE\_BY* \[default: min\]  
-    What to aggregate the measurements in each group with  
-
-  
-\[*possible values: *min, max, median, mean\]
-
-  - **-d**, **--sigma**=*SIGMA* \[default: 4.0\]  
-    Multiple of the dispersion measure (stddev or MAD) after which an outlier
-    is detected. If the HEAD measurement is within \`\[mean-\<d\>\*dispersion;
-    mean+\<d\>\*dispersion\]\`, it is considered acceptable
-
-  - **-D**, **--dispersion-method**=*DISPERSION\_METHOD*  
-    Method for calculating statistical dispersion. Choose between:
-    
-    **stddev**: Standard deviation - sensitive to outliers, use for normally
-    distributed data where you want to detect all changes.
-    
-    **mad**: Median Absolute Deviation - robust to outliers, use when data
-    has occasional spikes or you want to focus on typical changes.
-    
-    If not specified, uses the value from .gitperfconfig file, or defaults
-    to stddev.  
-
-  
-\[*possible values: *stddev, mad\]
-
-  - **-h**, **--help**  
-    Print help (see a summary with -h)
-
-
-
-git-perf-bump-epoch
-================
-# NAME
-
-bump-epoch - Accept HEAD commits measurement for audit, even if outside
-of range. This is allows to accept expected performance changes. This is
-accomplished by starting a new epoch for the given measurement. The
-epoch is configured in the git perf config file. A change to the epoch
-therefore has to be committed and will result in a new HEAD for which
-new measurements have to be taken
-
-# SYNOPSIS
-
-**bump-epoch** \<**-m**|**--measurement**\> \[**-h**|**--help**\]
-
-# DESCRIPTION
-
-Accept HEAD commits measurement for audit, even if outside of range.
-This is allows to accept expected performance changes. This is
-accomplished by starting a new epoch for the given measurement. The
-epoch is configured in the git perf config file. A change to the epoch
-therefore has to be committed and will result in a new HEAD for which
-new measurements have to be taken
-
-# OPTIONS
-
-  - **-m**, **--measurement**=*MEASUREMENT*  
-
-<!-- end list -->
-
-  - **-h**, **--help**  
-    Print help
-
-
-
-git-perf-measure
-================
-# NAME
-
-measure - Measure the runtime of the supplied command (in nanoseconds)
-
-# SYNOPSIS
-
-**measure** \[**-n**|**--repetitions**\] \<**-m**|**--measurement**\>
-\[**-k**|**--key-value**\] \[**-h**|**--help**\] \<*COMMAND*\>
-
-# DESCRIPTION
+## `git-perf measure`
 
 Measure the runtime of the supplied command (in nanoseconds)
 
-# OPTIONS
+**Usage:** `git-perf measure [OPTIONS] --measurement <NAME> -- <COMMAND>...`
 
-  - **-n**, **--repetitions**=*REPETITIONS* \[default: 1\]  
-    Repetitions
+###### **Arguments:**
 
-  - **-m**, **--measurement**=*NAME*  
-    Name of the measurement
+* `<COMMAND>` — Command to measure
 
-  - **-k**, **--key-value**=*KEY\_VALUE*  
-    Key-value pairs separated by =
+###### **Options:**
 
-  - **-h**, **--help**  
-    Print help
+* `-n`, `--repetitions <REPETITIONS>` — Repetitions
 
-  - \<*COMMAND*\>  
-    Command to measure
+  Default value: `1`
+* `-m`, `--measurement <NAME>` — Name of the measurement
+* `-k`, `--key-value <KEY_VALUE>` — Key-value pairs separated by '='
 
 
 
-git-perf-prune
-================
-# NAME
+## `git-perf add`
 
-prune - Remove all performance measurements for non-existent/unreachable
-objects. Will refuse to work if run on a shallow clone
+Add single measurement
 
-# SYNOPSIS
+**Usage:** `git-perf add [OPTIONS] --measurement <NAME> <VALUE>`
 
-**prune** \[**-h**|**--help**\]
+###### **Arguments:**
 
-# DESCRIPTION
+* `<VALUE>` — Measured value to be added
 
-Remove all performance measurements for non-existent/unreachable
-objects. Will refuse to work if run on a shallow clone
+###### **Options:**
 
-# OPTIONS
-
-  - **-h**, **--help**  
-    Print help
+* `-m`, `--measurement <NAME>` — Name of the measurement
+* `-k`, `--key-value <KEY_VALUE>` — Key-value pairs separated by '='
 
 
 
-git-perf-pull
-================
-# NAME
-
-pull - Pull performance results from remote
-
-# SYNOPSIS
-
-**pull** \[**-h**|**--help**\]
-
-# DESCRIPTION
-
-Pull performance results from remote
-
-# OPTIONS
-
-  - **-h**, **--help**  
-    Print help
-
-
-
-git-perf-push
-================
-# NAME
-
-push - Publish performance results to remote
-
-# SYNOPSIS
-
-**push** \[**-h**|**--help**\]
-
-# DESCRIPTION
+## `git-perf push`
 
 Publish performance results to remote
 
-# OPTIONS
-
-  - **-h**, **--help**  
-    Print help
+**Usage:** `git-perf push`
 
 
 
-git-perf-remove
-================
-# NAME
+## `git-perf pull`
 
-remove - Remove all performance measurements for commits that have been
-committed before the specified time period
+Pull performance results from remote
 
-# SYNOPSIS
-
-**remove** \<**--older-than**\> \[**-h**|**--help**\]
-
-# DESCRIPTION
-
-Remove all performance measurements for commits that have been committed
-before the specified time period
-
-# OPTIONS
-
-  - **--older-than**=*OLDER\_THAN*  
-
-<!-- end list -->
-
-  - **-h**, **--help**  
-    Print help
+**Usage:** `git-perf pull`
 
 
 
-git-perf-report
-================
-# NAME
-
-report - Create an HTML performance report
-
-# SYNOPSIS
-
-**report** \[**-o**|**--output**\] \[**-n**|**--max-count**\]
-\[**-m**|**--measurement**\] \[**-k**|**--key-value**\]
-\[**-s**|**--separate-by**\] \[**-a**|**--aggregate-by**\]
-\[**-h**|**--help**\]
-
-# DESCRIPTION
+## `git-perf report`
 
 Create an HTML performance report
 
-# OPTIONS
+**Usage:** `git-perf report [OPTIONS]`
 
-  - **-o**, **--output**=*OUTPUT* \[default: output.html\]  
-    HTML output file
+###### **Options:**
 
-  - **-n**, **--max-count**=*MAX\_COUNT* \[default: 40\]  
-    Limit the number of previous commits considered. HEAD is included in
-    this count
+* `-o`, `--output <OUTPUT>` — HTML output file
 
-  - **-m**, **--measurement**=*MEASUREMENT*  
-    Select an individual measurements instead of all
+  Default value: `output.html`
+* `-n`, `--max-count <MAX_COUNT>` — Limit the number of previous commits considered. HEAD is included in this count
 
-  - **-k**, **--key-value**=*KEY\_VALUE*  
-    Key-value pairs separated by =, select only matching measurements
+  Default value: `40`
+* `-m`, `--measurement <MEASUREMENT>` — Select an individual measurements instead of all
+* `-k`, `--key-value <KEY_VALUE>` — Key-value pairs separated by '=', select only matching measurements
+* `-s`, `--separate-by <SEPARATE_BY>` — Create individual traces in the graph by grouping with the value of this selector
+* `-a`, `--aggregate-by <AGGREGATE_BY>` — What to aggregate the measurements in each group with
 
-  - **-s**, **--separate-by**=*SEPARATE\_BY*  
-    Create individual traces in the graph by grouping with the value of
-    this selector
-
-  - **-a**, **--aggregate-by**=*AGGREGATE\_BY*  
-    What to aggregate the measurements in each group with  
-
-  
-\[*possible values: *min, max, median, mean\]
-
-  - **-h**, **--help**  
-    Print help
+  Possible values: `min`, `max`, `median`, `mean`
 
 
 
+
+## `git-perf audit`
+
+For given measurements, check perfomance deviations of the HEAD commit against `<n>` previous commits. Group previous results and aggregate their results before comparison.
+
+The audit can be configured to ignore statistically significant deviations if they are below a minimum relative deviation threshold. This helps filter out noise while still catching meaningful performance changes.
+
+Configuration is done via the `.gitperfconfig` file: - Measurement-specific: `[audit.measurement."name"].min_relative_deviation = 10.0` - Global: `[audit.global].min_relative_deviation = 5.0`
+
+When the relative deviation is below the threshold, the audit passes even if the z-score exceeds the sigma threshold. The relative deviation is calculated as: `|(head_value / tail_median - 1.0) * 100%|` where tail_median is the median of historical measurements (excluding HEAD).
+
+The sparkline visualization shows the range of measurements relative to the tail median (historical measurements only).
+
+**Usage:** `git-perf audit [OPTIONS] --measurement <MEASUREMENT>`
+
+###### **Options:**
+
+* `-m`, `--measurement <MEASUREMENT>`
+* `-n`, `--max-count <MAX_COUNT>` — Limit the number of previous commits considered. HEAD is included in this count
+
+  Default value: `40`
+* `-s`, `--selectors <SELECTORS>` — Key-value pair separated by "=" with no whitespaces to subselect measurements
+* `--min-measurements <MIN_MEASUREMENTS>` — Minimum number of measurements needed. If less, pass test and assume more measurements are needed. A minimum of two historic measurements are needed for proper evaluation of standard deviation
+
+  Default value: `2`
+* `-a`, `--aggregate-by <AGGREGATE_BY>` — What to aggregate the measurements in each group with
+
+  Default value: `min`
+
+  Possible values: `min`, `max`, `median`, `mean`
+
+* `-d`, `--sigma <SIGMA>` — Multiple of the stddev after which a outlier is detected. If the HEAD measurement is within `[mean-<d>*sigma; mean+<d>*sigma]`, it is considered acceptable
+
+  Default value: `4.0`
+* `-D`, `--dispersion-method <DISPERSION_METHOD>` — Method for calculating statistical dispersion (stddev or mad). If not specified, uses the value from .gitperfconfig file, or defaults to stddev
+
+  Possible values: `stddev`, `mad`
+
+
+
+
+## `git-perf bump-epoch`
+
+Accept HEAD commit's measurement for audit, even if outside of range. This is allows to accept expected performance changes. This is accomplished by starting a new epoch for the given measurement. The epoch is configured in the git perf config file. A change to the epoch therefore has to be committed and will result in a new HEAD for which new measurements have to be taken
+
+**Usage:** `git-perf bump-epoch --measurement <MEASUREMENT>`
+
+###### **Options:**
+
+* `-m`, `--measurement <MEASUREMENT>`
+
+
+
+## `git-perf remove`
+
+Remove all performance measurements for commits that have been committed before the specified time period
+
+**Usage:** `git-perf remove --older-than <OLDER_THAN>`
+
+###### **Options:**
+
+* `--older-than <OLDER_THAN>`
+
+
+
+## `git-perf prune`
+
+Remove all performance measurements for non-existent/unreachable objects. Will refuse to work if run on a shallow clone
+
+**Usage:** `git-perf prune`
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>

--- a/git_perf/Cargo.toml
+++ b/git_perf/Cargo.toml
@@ -41,6 +41,7 @@ unindent = "0.2.3"
 [build-dependencies]
 clap = { version="4", features=["derive"] }
 clap_mangen = "0.2.5"
+clap-markdown = "0.1.0"
 git_perf_cli_types = { version = "0.1.1", path = "../cli_types" }
 
 [dev-dependencies]

--- a/git_perf/build.rs
+++ b/git_perf/build.rs
@@ -10,11 +10,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let version = env::var("CARGO_PKG_VERSION").unwrap();
     let version: &'static str = Box::leak(version.into_boxed_str());
 
-    // Path calculation to the workspace root's man directory
-    let workspace_root = out_dir.join("../../../../");
+    // Path calculation to the workspace root
+    let workspace_root = out_dir.join("../../../../../");
     let man_dir = workspace_root.join("man").join("man1");
+    let docs_dir = workspace_root.join("docs");
 
     fs::create_dir_all(&man_dir).unwrap();
+    fs::create_dir_all(&docs_dir).unwrap();
 
     // Generate manpages for the main command and all subcommands
     let mut cmd = git_perf_cli_types::Cli::command();
@@ -36,6 +38,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let subcmd_man_path = man_dir.join(format!("git-perf-{subcmd_name}.1"));
         fs::write(&subcmd_man_path, &buffer).unwrap();
     }
+
+    // Generate markdown documentation
+    let main_markdown = clap_markdown::help_markdown::<git_perf_cli_types::Cli>();
+    let markdown_path = docs_dir.join("manpage.md");
+    fs::write(&markdown_path, &main_markdown).unwrap();
 
     // Tell cargo to re-run this if the CLI definition changes
     println!("cargo:rerun-if-changed=../git_perf_cli_types/src/lib.rs");

--- a/man/man1/git-perf-add.1
+++ b/man/man1/git-perf-add.1
@@ -1,0 +1,22 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH add 1  "add " 
+.SH NAME
+add \- Add single measurement
+.SH SYNOPSIS
+\fBadd\fR <\fB\-m\fR|\fB\-\-measurement\fR> [\fB\-k\fR|\fB\-\-key\-value\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIVALUE\fR> 
+.SH DESCRIPTION
+Add single measurement
+.SH OPTIONS
+.TP
+\fB\-m\fR, \fB\-\-measurement\fR \fI<NAME>\fR
+Name of the measurement
+.TP
+\fB\-k\fR, \fB\-\-key\-value\fR \fI<KEY_VALUE>\fR
+Key\-value pairs separated by \*(Aq=\*(Aq
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIVALUE\fR>
+Measured value to be added

--- a/man/man1/git-perf-audit.1
+++ b/man/man1/git-perf-audit.1
@@ -1,0 +1,50 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH audit 1  "audit " 
+.SH NAME
+audit \- For given measurements, check perfomance deviations of the HEAD commit against `<n>` previous commits. Group previous results and aggregate their results before comparison
+.SH SYNOPSIS
+\fBaudit\fR <\fB\-m\fR|\fB\-\-measurement\fR> [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-s\fR|\fB\-\-selectors\fR] [\fB\-\-min\-measurements\fR] [\fB\-a\fR|\fB\-\-aggregate\-by\fR] [\fB\-d\fR|\fB\-\-sigma\fR] [\fB\-D\fR|\fB\-\-dispersion\-method\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+For given measurements, check perfomance deviations of the HEAD commit against `<n>` previous commits. Group previous results and aggregate their results before comparison.
+.PP
+The audit can be configured to ignore statistically significant deviations if they are below a minimum relative deviation threshold. This helps filter out noise while still catching meaningful performance changes.
+.PP
+Configuration is done via the `.gitperfconfig` file: \- Measurement\-specific: `[audit.measurement."name"].min_relative_deviation = 10.0` \- Global: `[audit.global].min_relative_deviation = 5.0`
+.PP
+When the relative deviation is below the threshold, the audit passes even if the z\-score exceeds the sigma threshold. The relative deviation is calculated as: `|(head_value / tail_median \- 1.0) * 100%|` where tail_median is the median of historical measurements (excluding HEAD).
+.PP
+The sparkline visualization shows the range of measurements relative to the tail median (historical measurements only).
+.SH OPTIONS
+.TP
+\fB\-m\fR, \fB\-\-measurement\fR \fI<MEASUREMENT>\fR
+
+.TP
+\fB\-n\fR, \fB\-\-max\-count\fR \fI<MAX_COUNT>\fR [default: 40]
+Limit the number of previous commits considered. HEAD is included in this count
+.TP
+\fB\-s\fR, \fB\-\-selectors\fR \fI<SELECTORS>\fR
+Key\-value pair separated by "=" with no whitespaces to subselect measurements
+.TP
+\fB\-\-min\-measurements\fR \fI<MIN_MEASUREMENTS>\fR [default: 2]
+Minimum number of measurements needed. If less, pass test and assume more measurements are needed. A minimum of two historic measurements are needed for proper evaluation of standard deviation
+.TP
+\fB\-a\fR, \fB\-\-aggregate\-by\fR \fI<AGGREGATE_BY>\fR [default: min]
+What to aggregate the measurements in each group with
+.br
+
+.br
+[\fIpossible values: \fRmin, max, median, mean]
+.TP
+\fB\-d\fR, \fB\-\-sigma\fR \fI<SIGMA>\fR [default: 4.0]
+Multiple of the stddev after which a outlier is detected. If the HEAD measurement is within `[mean\-<d>*sigma; mean+<d>*sigma]`, it is considered acceptable
+.TP
+\fB\-D\fR, \fB\-\-dispersion\-method\fR \fI<DISPERSION_METHOD>\fR
+Method for calculating statistical dispersion (stddev or mad). If not specified, uses the value from .gitperfconfig file, or defaults to stddev
+.br
+
+.br
+[\fIpossible values: \fRstddev, mad]
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/man1/git-perf-bump-epoch.1
+++ b/man/man1/git-perf-bump-epoch.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH bump-epoch 1  "bump-epoch " 
+.SH NAME
+bump\-epoch \- Accept HEAD commit\*(Aqs measurement for audit, even if outside of range. This is allows to accept expected performance changes. This is accomplished by starting a new epoch for the given measurement. The epoch is configured in the git perf config file. A change to the epoch therefore has to be committed and will result in a new HEAD for which new measurements have to be taken
+.SH SYNOPSIS
+\fBbump\-epoch\fR <\fB\-m\fR|\fB\-\-measurement\fR> [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Accept HEAD commit\*(Aqs measurement for audit, even if outside of range. This is allows to accept expected performance changes. This is accomplished by starting a new epoch for the given measurement. The epoch is configured in the git perf config file. A change to the epoch therefore has to be committed and will result in a new HEAD for which new measurements have to be taken
+.SH OPTIONS
+.TP
+\fB\-m\fR, \fB\-\-measurement\fR \fI<MEASUREMENT>\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/man/man1/git-perf-measure.1
+++ b/man/man1/git-perf-measure.1
@@ -1,0 +1,25 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH measure 1  "measure " 
+.SH NAME
+measure \- Measure the runtime of the supplied command (in nanoseconds)
+.SH SYNOPSIS
+\fBmeasure\fR [\fB\-n\fR|\fB\-\-repetitions\fR] <\fB\-m\fR|\fB\-\-measurement\fR> [\fB\-k\fR|\fB\-\-key\-value\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fICOMMAND\fR> 
+.SH DESCRIPTION
+Measure the runtime of the supplied command (in nanoseconds)
+.SH OPTIONS
+.TP
+\fB\-n\fR, \fB\-\-repetitions\fR \fI<REPETITIONS>\fR [default: 1]
+Repetitions
+.TP
+\fB\-m\fR, \fB\-\-measurement\fR \fI<NAME>\fR
+Name of the measurement
+.TP
+\fB\-k\fR, \fB\-\-key\-value\fR \fI<KEY_VALUE>\fR
+Key\-value pairs separated by \*(Aq=\*(Aq
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fICOMMAND\fR>
+Command to measure

--- a/man/man1/git-perf-prune.1
+++ b/man/man1/git-perf-prune.1
@@ -1,0 +1,13 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH prune 1  "prune " 
+.SH NAME
+prune \- Remove all performance measurements for non\-existent/unreachable objects. Will refuse to work if run on a shallow clone
+.SH SYNOPSIS
+\fBprune\fR [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Remove all performance measurements for non\-existent/unreachable objects. Will refuse to work if run on a shallow clone
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/man/man1/git-perf-pull.1
+++ b/man/man1/git-perf-pull.1
@@ -1,0 +1,13 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH pull 1  "pull " 
+.SH NAME
+pull \- Pull performance results from remote
+.SH SYNOPSIS
+\fBpull\fR [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Pull performance results from remote
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/man/man1/git-perf-push.1
+++ b/man/man1/git-perf-push.1
@@ -1,0 +1,13 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH push 1  "push " 
+.SH NAME
+push \- Publish performance results to remote
+.SH SYNOPSIS
+\fBpush\fR [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Publish performance results to remote
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/man/man1/git-perf-remove.1
+++ b/man/man1/git-perf-remove.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH remove 1  "remove " 
+.SH NAME
+remove \- Remove all performance measurements for commits that have been committed before the specified time period
+.SH SYNOPSIS
+\fBremove\fR <\fB\-\-older\-than\fR> [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Remove all performance measurements for commits that have been committed before the specified time period
+.SH OPTIONS
+.TP
+\fB\-\-older\-than\fR \fI<OLDER_THAN>\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/man/man1/git-perf-report.1
+++ b/man/man1/git-perf-report.1
@@ -1,0 +1,35 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH report 1  "report " 
+.SH NAME
+report \- Create an HTML performance report
+.SH SYNOPSIS
+\fBreport\fR [\fB\-o\fR|\fB\-\-output\fR] [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-m\fR|\fB\-\-measurement\fR] [\fB\-k\fR|\fB\-\-key\-value\fR] [\fB\-s\fR|\fB\-\-separate\-by\fR] [\fB\-a\fR|\fB\-\-aggregate\-by\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Create an HTML performance report
+.SH OPTIONS
+.TP
+\fB\-o\fR, \fB\-\-output\fR \fI<OUTPUT>\fR [default: output.html]
+HTML output file
+.TP
+\fB\-n\fR, \fB\-\-max\-count\fR \fI<MAX_COUNT>\fR [default: 40]
+Limit the number of previous commits considered. HEAD is included in this count
+.TP
+\fB\-m\fR, \fB\-\-measurement\fR \fI<MEASUREMENT>\fR
+Select an individual measurements instead of all
+.TP
+\fB\-k\fR, \fB\-\-key\-value\fR \fI<KEY_VALUE>\fR
+Key\-value pairs separated by \*(Aq=\*(Aq, select only matching measurements
+.TP
+\fB\-s\fR, \fB\-\-separate\-by\fR \fI<SEPARATE_BY>\fR
+Create individual traces in the graph by grouping with the value of this selector
+.TP
+\fB\-a\fR, \fB\-\-aggregate\-by\fR \fI<AGGREGATE_BY>\fR
+What to aggregate the measurements in each group with
+.br
+
+.br
+[\fIpossible values: \fRmin, max, median, mean]
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/man/man1/git-perf.1
+++ b/man/man1/git-perf.1
@@ -1,0 +1,51 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH git-perf 1  "git-perf 0.0.0" 
+.SH NAME
+git\-perf
+.SH SYNOPSIS
+\fBgit\-perf\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Increase verbosity level (can be specified multiple times.) The first level sets level "info", second sets level "debug", and third sets level "trace" for the logger
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.SH SUBCOMMANDS
+.TP
+git\-perf\-measure(1)
+Measure the runtime of the supplied command (in nanoseconds)
+.TP
+git\-perf\-add(1)
+Add single measurement
+.TP
+git\-perf\-push(1)
+Publish performance results to remote
+.TP
+git\-perf\-pull(1)
+Pull performance results from remote
+.TP
+git\-perf\-report(1)
+Create an HTML performance report
+.TP
+git\-perf\-audit(1)
+For given measurements, check perfomance deviations of the HEAD commit against `<n>` previous commits. Group previous results and aggregate their results before comparison
+.TP
+git\-perf\-bump\-epoch(1)
+Accept HEAD commit\*(Aqs measurement for audit, even if outside of range. This is allows to accept expected performance changes. This is accomplished by starting a new epoch for the given measurement. The epoch is configured in the git perf config file. A change to the epoch therefore has to be committed and will result in a new HEAD for which new measurements have to be taken
+.TP
+git\-perf\-remove(1)
+Remove all performance measurements for commits that have been committed before the specified time period
+.TP
+git\-perf\-prune(1)
+Remove all performance measurements for non\-existent/unreachable objects. Will refuse to work if run on a shallow clone
+.TP
+git\-perf\-help(1)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.0.0


### PR DESCRIPTION
Merge master and resolve documentation conflicts by regenerating all docs using the new automated `clap-markdown` and `clap-mangen` process.

The merge introduced conflicts in `docs/manpage.md` due to a change in the documentation generation method. This PR resolves these by running `cargo build`, which now automatically regenerates `docs/manpage.md` using `clap-markdown` and all manpages in `man/man1/` using `clap-mangen`, ensuring all documentation is consistent and up-to-date with the CLI definition. The CI workflow has also been updated to validate the generated markdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-3aa40002-ec41-445b-9f37-1d09e1451b05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3aa40002-ec41-445b-9f37-1d09e1451b05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

