### PR TITLE
chore: enforce conventional commits and update docs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -21,11 +21,18 @@
 - Follow workspace conventions for shared dependencies
 - Maintain proper module organization
 
+## Pull Requests
+- Pull Request titles must follow the Conventional Commits specification (e.g., `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `test:`, `perf:`, `build:`, `ci:`, `revert:`). Use scope when helpful (e.g., `feat(cli_types): ...`).
+
+## Generated Documentation
+- If changes are made to the `cli_types` crate, ensure that any documentation regenerated as part of the build process is included in the commit (commit the regenerated docs alongside the code changes).
+
 ## Pre-submission Checklist
 1. Run `cargo fmt` to format code
 2. Run `cargo test -- --skip slow` to verify tests pass
 3. Run `cargo clippy` for additional code quality checks
 4. Ensure all changes compile without warnings
+5. If `cli_types` changed, commit regenerated documentation produced by the build.
 
 ## Commands to Run Before Submissions
 ```bash


### PR DESCRIPTION
Add rules to `.cursorrules` for Conventional Commit PR titles and committing regenerated documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-44ac7a04-2799-4fc7-9067-1c24d48cf9ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44ac7a04-2799-4fc7-9067-1c24d48cf9ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

