### PR TITLE
docs: fix documentation versioning inconsistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,16 +147,22 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-    - name: Check markdown is up to date
+    - name: Check documentation is up to date
       run: |
-        # Check that the generated markdown file exists
+        # Check that the generated documentation files exist
         if [[ ! -f "docs/manpage.md" ]]; then
           echo "Error: Generated markdown documentation not found at docs/manpage.md"
           exit 1
         fi
         
-        # Create a backup of the original file for comparison
+        if [[ ! -f "man/man1/git-perf.1" ]]; then
+          echo "Error: Generated manpage documentation not found at man/man1/git-perf.1"
+          exit 1
+        fi
+        
+        # Create backups of the original files for comparison
         cp docs/manpage.md /tmp/original_markdown.md
+        cp -r man/man1 /tmp/original_manpages
         
         # Temporarily set version to 0.0.0 to avoid version-based diffs
         sed -i 's/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/version = "0.0.0"/' git_perf/Cargo.toml
@@ -164,7 +170,7 @@ jobs:
         # Restore original version
         git checkout -- git_perf/Cargo.toml
         
-        # Compare with the newly generated version
+        # Check markdown documentation
         if ! diff -u /tmp/original_markdown.md docs/manpage.md > /tmp/markdown.diff; then
           echo "Error: Markdown documentation is out of date. A patch file has been created and will be uploaded as an artifact."
           echo ""
@@ -175,25 +181,8 @@ jobs:
           exit 1
         fi
         echo "Markdown documentation is up to date ✓"
-
-    - name: Check manpages are up to date
-      run: |
-        # Check that the generated manpage files exist
-        if [[ ! -f "man/man1/git-perf.1" ]]; then
-          echo "Error: Generated manpage documentation not found at man/man1/git-perf.1"
-          exit 1
-        fi
         
-        # Create a backup of the original manpage files for comparison
-        cp -r man/man1 /tmp/original_manpages
-        
-        # Temporarily set version to 0.0.0 to avoid version-based diffs
-        sed -i 's/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/version = "0.0.0"/' git_perf/Cargo.toml
-        cargo build
-        # Restore original version
-        git checkout -- git_perf/Cargo.toml
-        
-        # Compare with the newly generated version
+        # Check manpage documentation
         if ! diff -r /tmp/original_manpages man/man1 > /tmp/manpages.diff; then
           echo "Error: Manpage documentation is out of date. A patch file has been created and will be uploaded as an artifact."
           echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,49 @@ jobs:
         fi
         echo "Markdown documentation is up to date ✓"
 
+    - name: Check manpages are up to date
+      run: |
+        # Check that the generated manpage files exist
+        if [[ ! -f "man/man1/git-perf.1" ]]; then
+          echo "Error: Generated manpage documentation not found at man/man1/git-perf.1"
+          exit 1
+        fi
+        
+        # Create a backup of the original manpage files for comparison
+        cp -r man/man1 /tmp/original_manpages
+        
+        # Temporarily set version to 0.0.0 to avoid version-based diffs
+        sed -i 's/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/version = "0.0.0"/' git_perf/Cargo.toml
+        cargo build
+        # Restore original version
+        git checkout -- git_perf/Cargo.toml
+        
+        # Compare with the newly generated version
+        if ! diff -r /tmp/original_manpages man/man1 > /tmp/manpages.diff; then
+          echo "Error: Manpage documentation is out of date. A patch file has been created and will be uploaded as an artifact."
+          echo ""
+          echo "To fix this, run:"
+          echo "   cargo build"
+          echo ""
+          echo "The manpage documentation is automatically generated during the build process using clap_mangen."
+          exit 1
+        fi
+        echo "Manpage documentation is up to date ✓"
+
     - name: Upload markdown patch artifact
       uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: markdown-patch
         path: /tmp/markdown.diff
+        if-no-files-found: error
+
+    - name: Upload manpage patch artifact
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: manpage-patch
+        path: /tmp/manpages.diff
         if-no-files-found: error
 
   report:

--- a/git_perf/build.rs
+++ b/git_perf/build.rs
@@ -6,9 +6,8 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
-    // Get version from Cargo.toml
-    let version = env::var("CARGO_PKG_VERSION").unwrap();
-    let version: &'static str = Box::leak(version.into_boxed_str());
+    // Note: Version information is intentionally omitted from documentation
+    // to maintain consistency between markdown and manpage formats
 
     // Path calculation to the workspace root
     let workspace_root = out_dir.join("../../../../../");
@@ -20,7 +19,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Generate manpages for the main command and all subcommands
     let mut cmd = git_perf_cli_types::Cli::command();
-    cmd = cmd.version(version);
     let man = clap_mangen::Man::new(cmd);
     let mut buffer: Vec<u8> = Default::default();
     man.render(&mut buffer).unwrap();
@@ -29,7 +27,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Generate manpages for subcommands
     let mut cmd = git_perf_cli_types::Cli::command();
-    cmd = cmd.version(version);
     for subcmd in cmd.get_subcommands() {
         let man = clap_mangen::Man::new(subcmd.clone());
         let mut buffer: Vec<u8> = Default::default();

--- a/git_perf/build.rs
+++ b/git_perf/build.rs
@@ -6,9 +6,9 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
-    // Use 0.0.0 for documentation generation to avoid version-based diffs
-    // This matches the approach used in the GitHub CI workflow
-    let version = "0.0.0";
+    // Get version from Cargo.toml
+    let version = env::var("CARGO_PKG_VERSION").unwrap();
+    let version: &'static str = Box::leak(version.into_boxed_str());
 
     // Path calculation to the workspace root
     let workspace_root = out_dir.join("../../../../../");
@@ -40,9 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Generate markdown documentation
-    let mut cmd = git_perf_cli_types::Cli::command();
-    cmd = cmd.version(version);
-    let main_markdown = clap_markdown::help_markdown(cmd);
+    let main_markdown = clap_markdown::help_markdown::<git_perf_cli_types::Cli>();
     let markdown_path = docs_dir.join("manpage.md");
     fs::write(&markdown_path, &main_markdown).unwrap();
 

--- a/git_perf/build.rs
+++ b/git_perf/build.rs
@@ -6,8 +6,9 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
-    // Note: Version information is intentionally omitted from documentation
-    // to maintain consistency between markdown and manpage formats
+    // Use 0.0.0 for documentation generation to avoid version-based diffs
+    // This matches the approach used in the GitHub CI workflow
+    let version = "0.0.0";
 
     // Path calculation to the workspace root
     let workspace_root = out_dir.join("../../../../../");
@@ -19,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Generate manpages for the main command and all subcommands
     let mut cmd = git_perf_cli_types::Cli::command();
+    cmd = cmd.version(version);
     let man = clap_mangen::Man::new(cmd);
     let mut buffer: Vec<u8> = Default::default();
     man.render(&mut buffer).unwrap();
@@ -27,6 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Generate manpages for subcommands
     let mut cmd = git_perf_cli_types::Cli::command();
+    cmd = cmd.version(version);
     for subcmd in cmd.get_subcommands() {
         let man = clap_mangen::Man::new(subcmd.clone());
         let mut buffer: Vec<u8> = Default::default();
@@ -37,7 +40,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Generate markdown documentation
-    let main_markdown = clap_markdown::help_markdown::<git_perf_cli_types::Cli>();
+    let mut cmd = git_perf_cli_types::Cli::command();
+    cmd = cmd.version(version);
+    let main_markdown = clap_markdown::help_markdown(cmd);
     let markdown_path = docs_dir.join("manpage.md");
     fs::write(&markdown_path, &main_markdown).unwrap();
 


### PR DESCRIPTION
Remove version numbers from manpage generation to ensure consistency with markdown documentation.

This change prevents manpage CI checks from breaking when the project version is incremented, as the markdown documentation already omits version numbers.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec3fbf8a-f8c0-4d88-bcef-cc331116176f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec3fbf8a-f8c0-4d88-bcef-cc331116176f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

