### PR TITLE
refactor: Update CI to check manpage and markdown documentation 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,8 @@ jobs:
         export RUSTDOCFLAGS="-D warnings"
         cargo doc --no-deps
 
-  manpage-check:
-    name: manpage check
+  documentation-check:
+    name: Check documentation is up to date
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
@@ -147,16 +147,21 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-    - name: Check markdown is up to date
+    - name: Check documentation is up to date
       run: |
-        # Check that the generated markdown file exists
+        # Check that the generated files exist
         if [[ ! -f "docs/manpage.md" ]]; then
           echo "Error: Generated markdown documentation not found at docs/manpage.md"
           exit 1
         fi
+        if [[ ! -f "man/man1/git-perf.1" ]]; then
+          echo "Error: Generated manpage not found at man/man1/git-perf.1"
+          exit 1
+        fi
         
-        # Create a backup of the original file for comparison
+        # Create backups of the original files for comparison
         cp docs/manpage.md /tmp/original_markdown.md
+        cp man/man1/git-perf.1 /tmp/original_manpage.1
         
         # Temporarily set version to 0.0.0 to avoid version-based diffs
         sed -i 's/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/version = "0.0.0"/' git_perf/Cargo.toml
@@ -164,7 +169,7 @@ jobs:
         # Restore original version
         git checkout -- git_perf/Cargo.toml
         
-        # Compare with the newly generated version
+        # Compare markdown documentation
         if ! diff -u /tmp/original_markdown.md docs/manpage.md > /tmp/markdown.diff; then
           echo "Error: Markdown documentation is out of date. A patch file has been created and will be uploaded as an artifact."
           echo ""
@@ -175,19 +180,31 @@ jobs:
           exit 1
         fi
         echo "Markdown documentation is up to date ✓"
+        
+        # Compare manpage documentation
+        if ! diff -u /tmp/original_manpage.1 man/man1/git-perf.1 > /tmp/manpage.diff; then
+          echo "Error: Manpage documentation is out of date. A patch file has been created and will be uploaded as an artifact."
+          echo ""
+          echo "To fix this, run:"
+          echo "   cargo build"
+          echo ""
+          echo "The manpage documentation is automatically generated during the build process using clap_mangen."
+          exit 1
+        fi
+        echo "Manpage documentation is up to date ✓"
 
-    - name: Upload markdown patch artifact
+    - name: Upload documentation patch artifacts
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: markdown-patch
-        path: /tmp/markdown.diff
+        name: documentation-patches
+        path: /tmp/*.diff
         if-no-files-found: error
 
   report:
     name: git-perf
     if: always()
-    needs: [test, rustfmt, clippy, rustdoc, manpage-check]
+    needs: [test, rustfmt, clippy, rustdoc, documentation-check]
     uses: ./.github/workflows/report.yml
     with:
       additional-args: '-s rust'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git-perf"
-version = "0.17.2"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "average",

--- a/man/man1/git-perf.1
+++ b/man/man1/git-perf.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-perf 1  "git-perf 0.17.2" 
+.TH git-perf 1  "git-perf 0.0.0" 
 .SH NAME
 git\-perf
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Remove all performance measurements for non\-existent/unreachable objects. Will 
 git\-perf\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.17.2
+v0.0.0


### PR DESCRIPTION
Consolidate documentation checks in CI and normalize generated documentation versions to `0.0.0` to prevent version-based CI failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-945b9cbd-c2ad-434f-9272-9f3ad8dffcc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-945b9cbd-c2ad-434f-9272-9f3ad8dffcc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

