### PR TITLE
feat: add manpage generation script with environment variable support

### DIFF
--- a/.cursor/rules/pre-submission-checklist.mdc
+++ b/.cursor/rules/pre-submission-checklist.mdc
@@ -10,5 +10,5 @@ Before submitting code, ensure:
 2. Run `cargo test -- --skip slow` to verify tests pass
 3. Run `cargo clippy` for additional code quality checks
 4. Ensure all changes compile without warnings
-5. If `cli_types` changed, commit regenerated documentation produced by the build
+5. If `cli_types` changed, run `./scripts/generate-manpages.sh` (optionally with `GIT_PERF_VERSION=1.0.0`) and commit regenerated documentation
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,49 +149,7 @@ jobs:
         toolchain: stable
     - name: Check documentation is up to date
       run: |
-        # Check that the generated files exist
-        if [[ ! -f "docs/manpage.md" ]]; then
-          echo "Error: Generated markdown documentation not found at docs/manpage.md"
-          exit 1
-        fi
-        if [[ ! -f "man/man1/git-perf.1" ]]; then
-          echo "Error: Generated manpage not found at man/man1/git-perf.1"
-          exit 1
-        fi
-        
-        # Create backups of the original files for comparison
-        cp docs/manpage.md /tmp/original_markdown.md
-        cp man/man1/git-perf.1 /tmp/original_manpage.1
-        
-        # Temporarily set version to 0.0.0 to avoid version-based diffs
-        sed -i 's/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/version = "0.0.0"/' git_perf/Cargo.toml
-        cargo build
-        # Restore original version
-        git checkout -- git_perf/Cargo.toml
-        
-        # Compare markdown documentation
-        if ! diff -u /tmp/original_markdown.md docs/manpage.md > /tmp/markdown.diff; then
-          echo "Error: Markdown documentation is out of date. A patch file has been created and will be uploaded as an artifact."
-          echo ""
-          echo "To fix this, run:"
-          echo "   cargo build"
-          echo ""
-          echo "The markdown documentation is automatically generated during the build process using clap_markdown."
-          exit 1
-        fi
-        echo "Markdown documentation is up to date ✓"
-        
-        # Compare manpage documentation
-        if ! diff -u /tmp/original_manpage.1 man/man1/git-perf.1 > /tmp/manpage.diff; then
-          echo "Error: Manpage documentation is out of date. A patch file has been created and will be uploaded as an artifact."
-          echo ""
-          echo "To fix this, run:"
-          echo "   cargo build"
-          echo ""
-          echo "The manpage documentation is automatically generated during the build process using clap_mangen."
-          exit 1
-        fi
-        echo "Manpage documentation is up to date ✓"
+        ./scripts/generate-manpages.sh
 
     - name: Upload documentation patch artifacts
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -145,9 +145,14 @@ For evaluating the statistical robustness of different dispersion methods (stdde
 Both manpages and markdown documentation are automatically generated during the build process using `clap_mangen` and `clap_markdown`. To regenerate the documentation:
 
 ```bash
-# Build the project to generate both manpages and markdown documentation
-cargo build
+# Generate manpages and markdown documentation with normalized version (defaults to 0.0.0)
+./scripts/generate-manpages.sh
+
+# Or with a custom version
+GIT_PERF_VERSION=1.0.0 ./scripts/generate-manpages.sh
 ```
+
+The script uses the `GIT_PERF_VERSION` environment variable to set a normalized version for documentation generation, avoiding version-based diffs. If not specified, it defaults to `0.0.0`.
 
 The documentation is automatically generated during the build process:
 - Manpages are written to `target/man/man1/` directory

--- a/scripts/generate-manpages.sh
+++ b/scripts/generate-manpages.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Script to generate manpages and markdown documentation
+# This script uses a normalized version number to avoid version-based diffs in generated docs
+
+set -e
+
+# Default version to use for documentation generation (can be overridden with GIT_PERF_VERSION env var)
+NORMALIZED_VERSION="${GIT_PERF_VERSION:-0.0.0}"
+
+echo "Generating manpages and markdown documentation with version: $NORMALIZED_VERSION"
+
+# Check that the generated files exist
+if [[ ! -f "docs/manpage.md" ]]; then
+  echo "Error: Generated markdown documentation not found at docs/manpage.md"
+  exit 1
+fi
+if [[ ! -f "man/man1/git-perf.1" ]]; then
+  echo "Error: Generated manpage not found at man/man1/git-perf.1"
+  exit 1
+fi
+
+# Create backups of the original files for comparison
+cp docs/manpage.md /tmp/original_markdown.md
+cp man/man1/git-perf.1 /tmp/original_manpage.1
+
+# Generate manpages and markdown documentation with normalized version
+CARGO_PKG_VERSION="$NORMALIZED_VERSION" cargo build
+
+# Compare markdown documentation
+if ! diff -u /tmp/original_markdown.md docs/manpage.md > /tmp/markdown.diff; then
+  echo "Error: Markdown documentation is out of date. A patch file has been created at /tmp/markdown.diff"
+  echo ""
+  echo "To fix this, run:"
+  echo "   ./scripts/generate-manpages.sh"
+  echo ""
+  echo "Or with a custom version:"
+  echo "   GIT_PERF_VERSION=1.0.0 ./scripts/generate-manpages.sh"
+  echo ""
+  echo "The markdown documentation is automatically generated during the build process using clap_markdown."
+  exit 1
+fi
+echo "Markdown documentation is up to date ✓"
+
+# Compare manpage documentation
+if ! diff -u /tmp/original_manpage.1 man/man1/git-perf.1 > /tmp/manpage.diff; then
+  echo "Error: Manpage documentation is out of date. A patch file has been created at /tmp/manpage.diff"
+  echo ""
+  echo "To fix this, run:"
+  echo "   ./scripts/generate-manpages.sh"
+  echo ""
+  echo "Or with a custom version:"
+  echo "   GIT_PERF_VERSION=1.0.0 ./scripts/generate-manpages.sh"
+  echo ""
+  echo "The manpage documentation is automatically generated during the build process using clap_mangen."
+  exit 1
+fi
+echo "Manpage documentation is up to date ✓"


### PR DESCRIPTION
- Create scripts/generate-manpages.sh for automated manpage and markdown generation
- Use GIT_PERF_VERSION environment variable to normalize version (defaults to 0.0.0)
- Update CI workflow to use the new script instead of inline commands
- Update README.md with usage examples for the script
- Update cursor rules to reference the new script
- Eliminates need to modify Cargo.toml files during generation