### PR TITLE
fix: update build.rs to use GIT_PERF_VERSION environment variable

### DIFF
--- a/git_perf/build.rs
+++ b/git_perf/build.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
-    // Get version from Cargo.toml
-    let version = env::var("CARGO_PKG_VERSION").unwrap();
+    // Get version from environment variable or fallback to Cargo.toml
+    let version = env::var("GIT_PERF_VERSION").unwrap_or_else(|_| env::var("CARGO_PKG_VERSION").unwrap());
     let version: &'static str = Box::leak(version.into_boxed_str());
 
     // Path calculation to the workspace root


### PR DESCRIPTION
- Add support for GIT_PERF_VERSION environment variable in build.rs
- Fallback to CARGO_PKG_VERSION if GIT_PERF_VERSION is not set
- This enables the generate-manpages.sh script to work correctly
- Fixes issue where script couldn't override version for documentation generation