### PR TITLE
chore: track release binary size over time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,10 +165,52 @@ jobs:
   report:
     name: git-perf
     if: always()
-    needs: [test, rustfmt, clippy, rustdoc, documentation-check]
+    needs: [test, rustfmt, clippy, rustdoc, documentation-check, release-binary-size]
     uses: ./.github/workflows/report.yml
     with:
       additional-args: '-s rust'
       concurrency-token: gh-pages-${{ github.ref }}
       release: 'branch'
-      audit-args: '-m report -m report-size -s os="ubuntu-22.04" -s rust="stable" --min-measurements 10'
+      audit-args: '-m report -m report-size -m release-binary-size -s os="ubuntu-22.04" -s rust="stable" --min-measurements 10'
+
+  release-binary-size:
+    name: release-binary-size
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+      with:
+        fetch-depth: 40
+
+    - name: Set Git user and email
+      run: |
+        git config --global user.name "GitHub Actions Bot"
+        git config --global user.email "actions@github.com"
+
+    - name: Install Rust (stable)
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+
+    - name: Build optimized git-perf binary
+      run: cargo build --locked --release -p git-perf
+
+    - name: Measure binary size and push metric
+      run: |
+        set -euo pipefail
+        BIN=target/release/git-perf
+        if [ ! -f "$BIN" ]; then
+          echo "Binary not found at $BIN" >&2
+          ls -la target/release || true
+          exit 1
+        fi
+        BYTES=$(stat -c%s "$BIN")
+        echo "$BYTES" > metrics/release_binary_size.txt
+        ./target/release/git-perf add -m release-binary-size -k os=ubuntu-22.04 -k rust=stable "$BYTES"
+        ./target/release/git-perf push
+
+    - name: Upload size artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-binary-size
+        path: metrics/release_binary_size.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
           exit 1
         fi
         BYTES=$(stat -c%s "$BIN")
+        mkdir -p metrics
         echo "$BYTES" > metrics/release_binary_size.txt
         ./target/release/git-perf add -m release-binary-size -k os=ubuntu-22.04 -k rust=stable "$BYTES"
         ./target/release/git-perf push

--- a/.github/workflows/release-binary-size.yml
+++ b/.github/workflows/release-binary-size.yml
@@ -1,8 +1,0 @@
-name: deprecated-release-binary-size
-on:
-  workflow_dispatch:
-jobs:
-  noop:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "This workflow is deprecated; metric is handled in ci.yml"

--- a/.github/workflows/release-binary-size.yml
+++ b/.github/workflows/release-binary-size.yml
@@ -1,0 +1,77 @@
+name: release-binary-size
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  release-binary-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build optimized binary
+        run: |
+          cargo build --locked --release -p git-perf
+
+      - name: Determine binary path and size
+        id: size
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN=target/release/git-perf
+          if [ ! -f "$BIN" ]; then
+            echo "Binary not found at $BIN" >&2
+            ls -la target/release || true
+            exit 1
+          fi
+          # Size in bytes
+          BYTES=$(stat -c%s "$BIN")
+          echo "bytes=$BYTES" >> $GITHUB_OUTPUT
+          mkdir -p metrics
+          echo "$BYTES" > metrics/release_binary_size.txt
+          echo "Binary size (bytes): $BYTES"
+
+      - name: Upload size artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binary-size
+          path: metrics/release_binary_size.txt
+
+      - name: Upload binary artifact (optional)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-perf-binary
+          path: target/release/git-perf
+
+      - name: Report to git-perf (push only)
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          set -euo pipefail
+          BYTES=$(cat metrics/release_binary_size.txt)
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          ./target/release/git-perf add -m release-binary-size "$BYTES"
+          ./target/release/git-perf push

--- a/.github/workflows/release-binary-size.yml
+++ b/.github/workflows/release-binary-size.yml
@@ -1,77 +1,8 @@
-name: release-binary-size
-
+name: deprecated-release-binary-size
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-permissions:
-  contents: write
-
+  workflow_dispatch:
 jobs:
-  release-binary-size:
+  noop:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build optimized binary
-        run: |
-          cargo build --locked --release -p git-perf
-
-      - name: Determine binary path and size
-        id: size
-        shell: bash
-        run: |
-          set -euo pipefail
-          BIN=target/release/git-perf
-          if [ ! -f "$BIN" ]; then
-            echo "Binary not found at $BIN" >&2
-            ls -la target/release || true
-            exit 1
-          fi
-          # Size in bytes
-          BYTES=$(stat -c%s "$BIN")
-          echo "bytes=$BYTES" >> $GITHUB_OUTPUT
-          mkdir -p metrics
-          echo "$BYTES" > metrics/release_binary_size.txt
-          echo "Binary size (bytes): $BYTES"
-
-      - name: Upload size artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-binary-size
-          path: metrics/release_binary_size.txt
-
-      - name: Upload binary artifact (optional)
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: git-perf-binary
-          path: target/release/git-perf
-
-      - name: Report to git-perf (push only)
-        if: github.event_name == 'push'
-        shell: bash
-        run: |
-          set -euo pipefail
-          BYTES=$(cat metrics/release_binary_size.txt)
-          git config user.name "github-actions"
-          git config user.email "github-actions@users.noreply.github.com"
-          ./target/release/git-perf add -m release-binary-size "$BYTES"
-          ./target/release/git-perf push
+      - run: echo "This workflow is deprecated; metric is handled in ci.yml"


### PR DESCRIPTION
Add a GitHub Actions workflow to track the `git-perf` release binary size over time using `git-perf`.

---
<a href="https://cursor.com/background-agent?bcId=bc-25cf41cb-5a0a-4da8-b634-3b153f713f07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25cf41cb-5a0a-4da8-b634-3b153f713f07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

