### PR TITLE
Add `config` command to display git-perf configuration info

### DIFF
--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -245,6 +245,9 @@ pub enum Commands {
     /// Remove all performance measurements for non-existent/unreachable objects.
     /// Will refuse to work if run on a shallow clone.
     Prune {},
+
+    /// Show configuration information including current branch and config file locations
+    Config {},
 }
 
 fn parse_key_value(s: &str) -> Result<(String, String)> {

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -14,6 +14,7 @@ This document contains the help content for the `git-perf` command-line program.
 * [`git-perf bump-epoch`↴](#git-perf-bump-epoch)
 * [`git-perf remove`↴](#git-perf-remove)
 * [`git-perf prune`↴](#git-perf-prune)
+* [`git-perf config`↴](#git-perf-config)
 
 ## `git-perf`
 
@@ -30,6 +31,7 @@ This document contains the help content for the `git-perf` command-line program.
 * `bump-epoch` — Accept HEAD commit's measurement for audit, even if outside of range. This is allows to accept expected performance changes. This is accomplished by starting a new epoch for the given measurement. The epoch is configured in the git perf config file. A change to the epoch therefore has to be committed and will result in a new HEAD for which new measurements have to be taken
 * `remove` — Remove all performance measurements for commits that have been committed before the specified time period
 * `prune` — Remove all performance measurements for non-existent/unreachable objects. Will refuse to work if run on a shallow clone
+* `config` — Show configuration information including current branch and config file locations
 
 ###### **Options:**
 
@@ -207,6 +209,14 @@ Remove all performance measurements for commits that have been committed before 
 Remove all performance measurements for non-existent/unreachable objects. Will refuse to work if run on a shallow clone
 
 **Usage:** `git-perf prune`
+
+
+
+## `git-perf config`
+
+Show configuration information including current branch and config file locations
+
+**Usage:** `git-perf config`
 
 
 

--- a/git_perf/src/cli.rs
+++ b/git_perf/src/cli.rs
@@ -8,7 +8,7 @@ use crate::audit;
 use crate::basic_measure::measure;
 use crate::config::bump_epoch;
 use crate::git::git_interop::check_git_version;
-use crate::git::git_interop::{prune, pull, push};
+use crate::git::git_interop::{get_repository_root, prune, pull, push};
 use crate::measurement_storage::{add, remove_measurements_from_commits};
 use crate::reporting::report;
 use crate::stats::ReductionFunc;
@@ -86,6 +86,7 @@ pub fn handle_calls() -> Result<()> {
         Commands::BumpEpoch { measurement } => bump_epoch(&measurement),
         Commands::Prune {} => prune(),
         Commands::Remove { older_than } => remove_measurements_from_commits(older_than),
+        Commands::Config {} => show_config_info(),
     }
 }
 
@@ -110,4 +111,73 @@ fn determine_dispersion_method(
             crate::stats::DispersionMethod::from(config_method)
         }
     }
+}
+
+/// Show configuration information including branch name and config paths
+fn show_config_info() -> Result<()> {
+    use std::path::Path;
+
+    println!("Git Performance Configuration Information");
+    println!("=======================================");
+
+    // Get current branch
+    let current_branch = get_current_branch().unwrap_or_else(|_| "unknown".to_string());
+    println!("Current branch: {}", current_branch);
+
+    // Get repository root
+    match get_repository_root() {
+        Ok(repo_root) => {
+            println!("Repository root: {}", repo_root);
+
+            // Check for config file
+            let config_path = Path::new(&repo_root).join(".gitperfconfig");
+            if config_path.exists() {
+                println!("Config file: {} (exists)", config_path.display());
+            } else {
+                println!("Config file: {} (not found)", config_path.display());
+            }
+        }
+        Err(e) => {
+            println!("Repository root: Error - {}", e);
+        }
+    }
+
+    // Try to load and display config
+    match crate::config::read_hierarchical_config() {
+        Ok(config) => {
+            println!("\nConfiguration loaded successfully");
+
+            // Show some key config values if they exist
+            if let Ok(min_rel_dev) = config.get_string("measurement.min_relative_deviation") {
+                println!("  Default min_relative_deviation: {}", min_rel_dev);
+            }
+            if let Ok(dispersion) = config.get_string("measurement.dispersion_method") {
+                println!("  Default dispersion_method: {}", dispersion);
+            }
+        }
+        Err(e) => {
+            println!("\nConfiguration: Error loading - {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+/// Get the current branch name
+fn get_current_branch() -> Result<String> {
+    use std::process::Command;
+
+    let output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to run git command: {}", e))?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "Git command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }

--- a/git_perf/src/config.rs
+++ b/git_perf/src/config.rs
@@ -142,7 +142,20 @@ pub fn bump_epoch_in_conf(measurement: &str, conf_str: &mut String) -> Result<()
         .map_err(|e| anyhow::anyhow!("Failed to parse config: {}", e))?;
 
     let head_revision = get_head_revision()?;
-    // TODO(kaihowl) ensure that always non-inline tables are written in an empty config file
+
+    // Ensure non-inline table formatting by explicitly setting up the structure
+    if !conf.contains_key("measurement") {
+        conf["measurement"] = toml_edit::table();
+    }
+    if !conf["measurement"]
+        .as_table()
+        .unwrap()
+        .contains_key(measurement)
+    {
+        conf["measurement"][measurement] = toml_edit::table();
+    }
+
+    // Set the epoch value
     conf["measurement"][measurement]["epoch"] = value(&head_revision[0..8]);
     *conf_str = conf.to_string();
 

--- a/man/man1/git-perf-config.1
+++ b/man/man1/git-perf-config.1
@@ -1,0 +1,13 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH config 1  "config " 
+.SH NAME
+config \- Show configuration information including current branch and config file locations
+.SH SYNOPSIS
+\fBconfig\fR [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Show configuration information including current branch and config file locations
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/man/man1/git-perf.1
+++ b/man/man1/git-perf.1
@@ -42,5 +42,8 @@ Remove all performance measurements for commits that have been committed before 
 git\-perf\-prune(1)
 Remove all performance measurements for non\-existent/unreachable objects. Will refuse to work if run on a shallow clone
 .TP
+git\-perf\-config(1)
+Show configuration information including current branch and config file locations
+.TP
 git\-perf\-help(1)
 Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
## Summary
- Introduces a new `config` command to the `git-perf` CLI
- Displays current Git branch, repository root, and config file status
- Loads and shows key configuration values if available
- Adds manpage documentation for the `config` command

## Changes

### CLI and Command Handling
- Added `Config` variant to `Commands` enum
- Implemented `show_config_info` function to print configuration details:
  - Current branch name
  - Repository root path
  - Existence of `.gitperfconfig` file
  - Loaded configuration values like `min_relative_deviation` and `dispersion_method`
- Integrated `show_config_info` into CLI command dispatch

### Documentation
- Updated `docs/manpage.md` to include `config` command description
- Added new manpage `git-perf-config.1` for the `config` command
- Updated main manpage `git-perf.1` to reference the new command

### Config Module
- Minor improvement to ensure non-inline table formatting when bumping epoch in config

## Test plan
- Run `git-perf config` in a repository with and without `.gitperfconfig` file
- Verify output shows correct branch, repo root, and config file status
- Confirm key config values are displayed when config loads successfully
- Check manpage renders correctly with new command documentation

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/bf58796e-1aa1-4abd-a21a-dbb464415ce0