### PR TITLE
chore: remove outdated TODO #96 comment about no-separator option

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -111,16 +111,7 @@ fn raw_add_note_line_to_head(line: &str) -> Result<(), GitError> {
     }
 
     capture_git_output(
-        &[
-            "notes",
-            "--ref",
-            &temp_target,
-            "append",
-            // TODO #96
-            // "--no-separator",
-            "-m",
-            line,
-        ],
+        &["notes", "--ref", &temp_target, "append", "-m", line],
         &None,
     )?;
 


### PR DESCRIPTION
## Summary
- Remove outdated TODO #96 comment from `raw_add_note_line_to_head` function in git_interop.rs
- The no-separator option was already disabled in PR #97 for git version compatibility  
- This is a simple cleanup of an outdated comment

## Test plan
- [x] Run `cargo fmt` to ensure proper formatting
- [x] Run `cargo clippy` for linting checks
- [x] Verify the change only removes the comment and reformats the array

🤖 Generated with [Claude Code](https://claude.ai/code)