### PR TITLE
config(audit): set min relative deviation to 10% for report-size measurement

### DIFF
--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -1,1 +1,9 @@
-measurement = { report-size = { epoch = "f3709134" } , report = { epoch = "fe6d0205" } , test-measure2 = { epoch = "b5f56987" } }
+[measurement."report-size"]
+epoch = "f3709134"
+min_relative_deviation = 10.0
+
+[measurement."report"]
+epoch = "fe6d0205"
+
+[measurement."test-measure2"]
+epoch = "b5f56987"


### PR DESCRIPTION
## Summary
- Updates the `.gitperfconfig` to set `min_relative_deviation` to 10.0 for the `report-size` measurement
- Refactors the config format for better readability and consistency

## Changes

### Configuration Update
- Modified `.gitperfconfig`:
  - Changed `measurement` section to use TOML table format for each measurement
  - Added `min_relative_deviation = 10.0` under `[measurement."report-size"]`
  - Kept existing `epoch` values for all measurements unchanged

## Test plan
- [x] Verify that the `.gitperfconfig` loads correctly with the new format
- [x] Confirm that the `min_relative_deviation` setting is applied for the `report-size` measurement
- [x] Ensure no regressions in measurement parsing or performance reporting

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/bc60ba82-f9fc-4f3a-8a88-a90de171ebd5