### PR TITLE
Fix nextest skip argument syntax in documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,12 @@ cargo fmt
 cargo clippy
 
 # Run tests (excluding slow ones)
-cargo nextest run --skip slow
+cargo nextest run -- --skip slow
 ```
 
 ## Testing Policy
 
-- **Test command**: `cargo nextest run --skip slow` (excludes slow tests)
+- **Test command**: `cargo nextest run -- --skip slow` (excludes slow tests)
 - Ensure all tests pass before submitting code
 - Use `cargo nextest run` for full test suite when needed
 - This is the standard command for CI and local pre-submit
@@ -155,7 +155,7 @@ Before submitting any code, ensure:
 
 ### Code Quality
 1. ✅ Run `cargo fmt` to format code
-2. ✅ Run `cargo nextest run --skip slow` to verify tests pass
+2. ✅ Run `cargo nextest run -- --skip slow` to verify tests pass
 3. ✅ Run `cargo clippy` for additional code quality checks
 4. ✅ Ensure all changes compile without warnings
 5. ✅ If `cli_types` changed, run `./scripts/generate-manpages.sh` and commit regenerated documentation
@@ -177,7 +177,7 @@ Before submitting any code, ensure:
 ### Final Verification Commands
 ```bash
 # Verify formatting and tests
-cargo fmt --check && cargo nextest run --skip slow && cargo clippy
+cargo fmt --check && cargo nextest run -- --skip slow && cargo clippy
 
 # Check commit message format (should show proper conventional format)
 git log --oneline -1

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ This project uses [nextest](https://nexte.st/) for faster, more reliable test ex
 
 ```bash
 # Development testing (recommended - skips slow tests)
-cargo nextest run --skip slow
+cargo nextest run -- --skip slow
 
 # Full test suite
 cargo nextest run


### PR DESCRIPTION
## Summary
- Corrects the usage of the `--skip` argument for `cargo nextest run` in documentation files
- Updates `AGENTS.md` and `README.md` to use `cargo nextest run -- --skip slow` instead of `cargo nextest run --skip slow`

## Changes

### Documentation Updates
- **AGENTS.md**: Fixed test command examples to include the double dash `--` before `--skip slow` to match correct nextest CLI usage
- **README.md**: Updated development testing command to use the correct syntax with `-- --skip slow`

## Test plan
- Verified that the updated commands reflect the correct usage as per nextest documentation
- Ensured no other references to the incorrect `--skip` argument usage remain in the changed files

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d6ec349c-cb88-4087-9685-2043f9f38ab2