### PR TITLE
refactor(data): centralize data structures by moving Commit to data.rs

### DIFF
--- a/git_perf/src/data.rs
+++ b/git_perf/src/data.rs
@@ -20,3 +20,9 @@ pub struct MeasurementData {
     pub val: f64,
     pub key_values: HashMap<String, String>,
 }
+
+#[derive(Debug, PartialEq)]
+pub struct Commit {
+    pub commit: String,
+    pub measurements: Vec<MeasurementData>,
+}

--- a/git_perf/src/measurement_retrieval.rs
+++ b/git_perf/src/measurement_retrieval.rs
@@ -1,5 +1,5 @@
 use crate::{
-    data::{CommitSummary, MeasurementData, MeasurementSummary},
+    data::{Commit, CommitSummary, MeasurementData, MeasurementSummary},
     git::git_interop::{self},
     stats::{NumericReductionFunc, ReductionFunc},
 };
@@ -72,12 +72,6 @@ where
             val: aggregate_val?,
         })
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct Commit {
-    pub commit: String,
-    pub measurements: Vec<MeasurementData>,
 }
 
 // Copying all measurements is currently necessary due to deserialization from git notes.

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -13,10 +13,9 @@ use plotly::{
     Configuration, Layout, Plot,
 };
 
-// TODO(kaihowl) find central place for the data structures
 use crate::{
-    data::{MeasurementData, MeasurementSummary},
-    measurement_retrieval::{self, Commit, MeasurementReducer},
+    data::{Commit, MeasurementData, MeasurementSummary},
+    measurement_retrieval::{self, MeasurementReducer},
     serialization::{serialize_single, DELIMITER},
     stats::ReductionFunc,
 };


### PR DESCRIPTION
## Summary
- Moved `Commit` struct definition from `measurement_retrieval.rs` to `data.rs` for better data organization
- Removed duplicate `Commit` struct definition in `measurement_retrieval.rs`
- Cleaned up imports and usage of `Commit` struct across modules
- Removed a TODO comment related to data structures in `reporting.rs`

## Changes

### Data Module
- Added `Commit` struct with fields `commit` (String) and `measurements` (Vec<MeasurementData>)

### Measurement Retrieval
- Updated imports to use `Commit` from `data.rs`
- Removed redundant `Commit` struct definition

### Reporting
- Cleaned up imports to use `Commit` from `data.rs`
- Removed TODO comment about finding a central place for data structures

## Test plan
- Ensure existing tests for commit measurement retrieval and reporting pass without errors
- Verify no regressions in data handling related to commits and measurements

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e1e97267-3eba-497b-bf33-118b01fb5e4d