### PR TITLE
docs(test): clarify constraint on using bare remote in test_shallow.sh

### DIFF
--- a/test/test_shallow.sh
+++ b/test/test_shallow.sh
@@ -54,8 +54,10 @@ fi
 
 popd
 
-# TODO(kaihowl) document the constraint of not using a working copy to pull measurements from
-# The original test case failed as we used a different working copy as a remote instead of a bare remote.
+# CONSTRAINT: Must use a bare remote repository, not a working copy
+# When pulling measurements, the remote must be a bare repository. Using a working copy
+# as a remote will cause test failures. The original test case failed because it used
+# a different working copy as a remote instead of a bare remote.
 
 # The shallow warning for a PR-branch with a merge as HEAD should be counting the first parent's history.
 # This is already the default behavior for git-fetch with the depth option.


### PR DESCRIPTION
## Summary
- Clarifies the constraint in `test_shallow.sh` regarding the use of a bare remote repository
- Updates comments to explain why using a working copy as a remote causes test failures

## Changes

### Test Script Documentation
- Replaced TODO comment with a clear explanation:
  - Must use a bare remote repository, not a working copy
  - Using a working copy as a remote causes test failures because the original test case used a different working copy instead of a bare remote

## Test plan
- No code changes affecting functionality
- Verified that the updated comment accurately describes the constraint and reason for test failures
- Ensures better understanding for future contributors working with the test script

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/49e1ebc5-2c67-4e60-880e-9dc1b3b9aca3