### PR TITLE
docs(reporting): replace TODO with explanatory comment for axis reversal

### DIFF
--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -39,9 +39,9 @@ trait Reporter<'a> {
 
 struct PlotlyReporter {
     plot: Plot,
-    // TODO(kaihowl) hack until we can auto_range 'reverse' the axis in plotly directly
-    // Note: plotly-rs 0.8.3 does not support autorange="reversed" - only accepts bool values
-    // This manual reversal calculation is the only viable approach for axis reversal in this version
+    // Manual axis data reversal implementation: plotly-rs does not support autorange="reversed"
+    // The autorange parameter only accepts boolean values, requiring manual index reversal
+    // to achieve reversed axis display (newest commits on left, oldest on right)
     size: usize,
 }
 

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -41,7 +41,7 @@ struct PlotlyReporter {
     plot: Plot,
     // Manual axis data reversal implementation: plotly-rs does not support autorange="reversed"
     // The autorange parameter only accepts boolean values, requiring manual index reversal
-    // to achieve reversed axis display (newest commits on left, oldest on right)
+    // to achieve reversed axis display (newest commits on right, oldest on left)
     // See: https://github.com/kaihowl/git-perf/issues/339
     size: usize,
 }

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -42,6 +42,7 @@ struct PlotlyReporter {
     // Manual axis data reversal implementation: plotly-rs does not support autorange="reversed"
     // The autorange parameter only accepts boolean values, requiring manual index reversal
     // to achieve reversed axis display (newest commits on left, oldest on right)
+    // See: https://github.com/kaihowl/git-perf/issues/339
     size: usize,
 }
 


### PR DESCRIPTION
## Summary
- Replace TODO comment in PlotlyReporter with clear explanatory documentation
- Document why manual axis reversal is necessary due to plotly-rs limitations
- Clarify that autorange="reversed" is not supported in plotly-rs (even in latest 0.13.5)

## Details
The TODO comment at line 42 in reporting.rs was referencing a hack for axis reversal. Research into plotly-rs versions revealed that even the latest version (0.13.5) still doesn't support autorange="reversed" - the autorange parameter only accepts boolean values.

This change replaces the TODO with clear documentation explaining:
- Why manual reversal is implemented
- That plotly-rs doesn't support autorange="reversed" 
- The purpose of the manual index calculation (newest commits on left, oldest on right)

## Test plan
- [x] Code compiles without warnings
- [x] cargo fmt passes
- [x] cargo clippy passes
- [x] No functional changes - documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)