### PR TITLE
chore(ci): force reinstall cargo-nextest in mutation testing workflow

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -66,7 +66,7 @@ jobs:
           ${{ runner.os }}-cargo-
 
     - name: Install nextest
-      run: cargo install cargo-nextest --locked
+      run: cargo install cargo-nextest --locked --force
 
     - name: Install cargo-mutants
       run: |


### PR DESCRIPTION
## Summary
- Fixes mutation testing workflow error: `binary 'cargo-nextest' already exists in destination`
- Added `--force` flag to cargo-nextest installation to handle cached binaries

## Changes
- Modified `.github/workflows/mutation-testing.yml`:
  - Updated line 69 to use `cargo install cargo-nextest --locked --force`
  - Matches pattern used for cargo-mutants installation (line 74)

## Root Cause
The workflow caches `~/.cargo/bin/` directory (line 58), so when cache is restored, cargo-nextest binary already exists and installation fails without `--force` flag.

## Test plan
- [x] Verify workflow syntax is correct
- [ ] Confirm mutation testing workflow runs successfully on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>