### PR TITLE
docs(cli): clarify that remove only affects published measurements

### DIFF
--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -237,6 +237,10 @@ pub enum Commands {
 
     /// Remove all performance measurements for commits that have been committed
     /// before the specified time period.
+    ///
+    /// Note: Only published measurements (i.e., those that have been pushed to the
+    /// remote repository) can be removed. Local unpublished measurements are not
+    /// affected by this operation.
     Remove {
         #[arg(long = "older-than", value_parser = parse_datetime_value_now)]
         older_than: DateTime<Utc>,

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -192,7 +192,9 @@ Accept HEAD commit's measurement for audit, even if outside of range. This is al
 
 ## `git-perf remove`
 
-Remove all performance measurements for commits that have been committed before the specified time period
+Remove all performance measurements for commits that have been committed before the specified time period.
+
+Note: Only published measurements (i.e., those that have been pushed to the remote repository) can be removed. Local unpublished measurements are not affected by this operation.
 
 **Usage:** `git-perf remove --older-than <OLDER_THAN>`
 

--- a/man/man1/git-perf-remove.1
+++ b/man/man1/git-perf-remove.1
@@ -6,11 +6,13 @@ remove \- Remove all performance measurements for commits that have been committ
 .SH SYNOPSIS
 \fBremove\fR <\fB\-\-older\-than\fR> [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-Remove all performance measurements for commits that have been committed before the specified time period
+Remove all performance measurements for commits that have been committed before the specified time period.
+.PP
+Note: Only published measurements (i.e., those that have been pushed to the remote repository) can be removed. Local unpublished measurements are not affected by this operation.
 .SH OPTIONS
 .TP
 \fB\-\-older\-than\fR \fI<OLDER_THAN>\fR
 
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/test/test_remove.sh
+++ b/test/test_remove.sh
@@ -70,7 +70,6 @@ num_measurements=$(git perf report -o - | wc -l)
 [[ ${num_measurements} -eq 1 ]] || exit 1
 
 # Only published measurements can be expired
-# TODO(kaihowl) clarify documentation!
 git perf push
 
 # TODO(kaihowl) specify >= or > precisely


### PR DESCRIPTION
## Summary
- Added documentation to the `remove` command clarifying that only published measurements (pushed to remote) can be removed
- Removed TODO comment from test suite that requested this documentation clarification
- Updated generated manpages and markdown documentation

## Changes
- **cli_types/src/lib.rs**: Added doc comment explaining that only published measurements are affected by the remove operation
- **test/test_remove.sh**: Removed TODO comment requesting documentation clarification
- **docs/manpage.md**: Auto-generated documentation update
- **man/man1/git-perf-remove.1**: Auto-generated manpage update

## Why
The test suite contained a TODO comment noting that it needed documentation clarification about the requirement that measurements must be published (pushed) before they can be removed. This is a behavioral constraint of the `remove` operation that was not clearly documented in the CLI help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)