### PR TITLE
docs(cli): clarify that remove only affects published measurements

### DIFF
--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -236,7 +236,7 @@ pub enum Commands {
     },
 
     /// Remove all performance measurements for commits that have been committed
-    /// before the specified time period.
+    /// at or before the specified time (inclusive boundary, uses <=).
     ///
     /// Note: Only published measurements (i.e., those that have been pushed to the
     /// remote repository) can be removed. Local unpublished measurements are not

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -28,7 +28,7 @@ This document contains the help content for the `git-perf` command-line program.
 * `report` — Create an HTML performance report
 * `audit` — For given measurements, check perfomance deviations of the HEAD commit against `<n>` previous commits. Group previous results and aggregate their results before comparison
 * `bump-epoch` — Accept HEAD commit's measurement for audit, even if outside of range. This is allows to accept expected performance changes. This is accomplished by starting a new epoch for the given measurement. The epoch is configured in the git perf config file. A change to the epoch therefore has to be committed and will result in a new HEAD for which new measurements have to be taken
-* `remove` — Remove all performance measurements for commits that have been committed before the specified time period
+* `remove` — Remove all performance measurements for commits that have been committed at or before the specified time (inclusive boundary, uses <=)
 * `prune` — Remove all performance measurements for non-existent/unreachable objects. Will refuse to work if run on a shallow clone
 
 ###### **Options:**
@@ -192,7 +192,7 @@ Accept HEAD commit's measurement for audit, even if outside of range. This is al
 
 ## `git-perf remove`
 
-Remove all performance measurements for commits that have been committed before the specified time period.
+Remove all performance measurements for commits that have been committed at or before the specified time (inclusive boundary, uses <=).
 
 Note: Only published measurements (i.e., those that have been pushed to the remote repository) can be removed. Local unpublished measurements are not affected by this operation.
 

--- a/man/man1/git-perf-remove.1
+++ b/man/man1/git-perf-remove.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH remove 1  "remove " 
 .SH NAME
-remove \- Remove all performance measurements for commits that have been committed before the specified time period
+remove \- Remove all performance measurements for commits that have been committed at or before the specified time (inclusive boundary, uses <=)
 .SH SYNOPSIS
 \fBremove\fR <\fB\-\-older\-than\fR> [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-Remove all performance measurements for commits that have been committed before the specified time period.
+Remove all performance measurements for commits that have been committed at or before the specified time (inclusive boundary, uses <=).
 .PP
 Note: Only published measurements (i.e., those that have been pushed to the remote repository) can be removed. Local unpublished measurements are not affected by this operation.
 .SH OPTIONS

--- a/man/man1/git-perf.1
+++ b/man/man1/git-perf.1
@@ -37,7 +37,7 @@ git\-perf\-bump\-epoch(1)
 Accept HEAD commit\*(Aqs measurement for audit, even if outside of range. This is allows to accept expected performance changes. This is accomplished by starting a new epoch for the given measurement. The epoch is configured in the git perf config file. A change to the epoch therefore has to be committed and will result in a new HEAD for which new measurements have to be taken
 .TP
 git\-perf\-remove(1)
-Remove all performance measurements for commits that have been committed before the specified time period
+Remove all performance measurements for commits that have been committed at or before the specified time (inclusive boundary, uses <=)
 .TP
 git\-perf\-prune(1)
 Remove all performance measurements for non\-existent/unreachable objects. Will refuse to work if run on a shallow clone

--- a/test/test_remove.sh
+++ b/test/test_remove.sh
@@ -72,9 +72,8 @@ num_measurements=$(git perf report -o - | wc -l)
 # Only published measurements can be expired
 git perf push
 
-# TODO(kaihowl) specify >= or > precisely
-# These tests will become flaky if this is incorrectly set as we remove excactly on 7 day boundaries
-# If the test runs quickly enough, the offset between commits and the invocation of removal will be exactly 7 days
+# Note: --older-than uses <= (inclusive), so measurements at exactly 7 days will be removed
+# These tests will become flaky if run at exactly the 7 day boundary
 echo "Remove measurements on commits older than 7 days"
 git perf remove --older-than 7d || bash -i
 num_measurements=$(git perf report -o - | wc -l)


### PR DESCRIPTION
## Summary

- Clarified that the `--older-than` flag uses an inclusive boundary (`<=`)
- Updated CLI documentation to explicitly state that commits at or before the specified time will be removed
- Regenerated manpages and markdown documentation to reflect the changes
- Resolved TODO comment in test file with explanatory note about the inclusive boundary behavior

## Background

The implementation in `git_perf/src/git/git_interop.rs:375` uses `timestamp <= oldest_timestamp`, meaning the boundary is inclusive. However, the previous documentation said "before the specified time period" which was ambiguous.

## Test Plan

- [x] Ran `cargo fmt` to format code
- [x] Ran `cargo clippy` for linting (no new warnings)
- [x] Ran `cargo test` (existing test failures are unrelated to this change)
- [x] Verified manpage documentation was regenerated correctly
- [x] Confirmed test file comment now accurately describes the behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)