### PR TITLE
test: add assert_output_contains helper function to simplify test assertions

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -40,3 +40,27 @@ function cd_temp_repo() {
   create_commit
   create_commit
 }
+
+function assert_output_contains() {
+  local output="$1"
+  local expected="$2"
+  local error_message="${3:-Missing expected string in output}"
+
+  if [[ $output != *"$expected"* ]]; then
+    echo "$error_message:"
+    echo "$output"
+    exit 1
+  fi
+}
+
+function assert_output_not_contains() {
+  local output="$1"
+  local unexpected="$2"
+  local error_message="${3:-Unexpected string found in output}"
+
+  if [[ $output == *"$unexpected"* ]]; then
+    echo "$error_message:"
+    echo "$output"
+    exit 1
+  fi
+}

--- a/test/test_pull_messages.sh
+++ b/test/test_pull_messages.sh
@@ -11,11 +11,7 @@ echo Pull in repo without a remote
 cd_empty_repo
 
 output="$(git perf pull 2>&1 1>/dev/null)" && exit 1
-if [[ $output != *"No upstream found"* ]]; then
-  echo "Missing 'No upstream found' from output:"
-  echo "$output"
-  exit 1
-fi
+assert_output_contains "$output" "No upstream found" "Missing 'No upstream found' from output"
 
 echo Pull from remote without measurements
 
@@ -39,13 +35,8 @@ git commit -m 'first commit'
 
 git push
 
-# TODO(kaihowl) move functionality for check for output in common function
 output="$(git perf pull 2>&1 1>/dev/null)" && exit 1
-if [[ $output != *'Remote repository is empty or has never been pushed to'* ]]; then
-  echo "Missing 'Remote repository is empty or has never been pushed to' in output:"
-  echo "$output"
-  exit 1
-fi
+assert_output_contains "$output" "Remote repository is empty or has never been pushed to" "Missing 'Remote repository is empty or has never been pushed to' in output"
 
 cd "$root"
 git clone "$orig" repo1
@@ -57,8 +48,4 @@ git perf add -m test-measure 12
 git perf push
 
 output=$(git perf pull 2>/dev/null) || exit 1
-if [[ $output != *'Already up to date'* ]]; then
-  echo "Missing 'Already up to date' in output:"
-  echo "$output"
-  exit 1
-fi
+assert_output_contains "$output" "Already up to date" "Missing 'Already up to date' in output"


### PR DESCRIPTION
## Summary
- Resolves TODO in test_pull_messages.sh by extracting repeated output checking pattern
- Adds `assert_output_contains` and `assert_output_not_contains` helper functions to test/common.sh
- Refactors test_pull_messages.sh to use the new helper functions, reducing code duplication

## Changes
- Added two new helper functions to `test/common.sh`:
  - `assert_output_contains`: Checks if output contains expected string
  - `assert_output_not_contains`: Checks if output doesn't contain unexpected string
- Updated `test/test_pull_messages.sh` to use these helpers instead of inline if-statements
- Removed TODO comment that requested this refactoring

## Benefits
- **Reduces code duplication**: The pattern was repeated 3 times in test_pull_messages.sh alone
- **Improves readability**: Test assertions are now more concise and clear
- **Reusable**: Other test files can now use these helpers (there are 20+ similar patterns in the test suite)
- **Consistent error handling**: All output assertions now follow the same pattern

## Test Plan
- Existing test suite should pass (test_pull_messages.sh behavior unchanged)
- Helper functions follow the same logic as the inline code they replace

🤖 Generated with [Claude Code](https://claude.com/claude-code)