### PR TITLE
test: remove outdated TODO comment in test_prune.sh

### DIFF
--- a/test/test_prune.sh
+++ b/test/test_prune.sh
@@ -4,7 +4,6 @@ set -e
 set -x
 
 # TODO(kaihowl) add output expectations for report use cases (based on markdown?)
-# TODO(kaihowl) running without a git repo as current working directory
 # TODO(kaihowl) allow pushing to different remotes
 
 script_dir=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)


### PR DESCRIPTION
## Summary
- Removed outdated TODO comment from `test/test_prune.sh`
- The TODO suggested adding a test for "running without a git repo as current working directory"
- This test already exists (lines 39-46) and validates the error handling when running `git perf prune` outside a git repository

## Test plan
- Verified that the test implementation on lines 39-46 matches the TODO requirement
- Ran `cargo fmt` (no changes needed for shell script)
- Confirmed no functional changes to any tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)