### PR TITLE
test: remove outdated TODO comment about prune deprecation

### DIFF
--- a/test/test_prune.sh
+++ b/test/test_prune.sh
@@ -55,7 +55,6 @@ git perf add -m test 5
 # Must push once to create the remote perf branch
 git perf push
 
-# TODO(kaihowl) probably should be deprecated and subsumed into the normal remove operation
 git perf prune
 
 nr_notes=$(git notes --ref=refs/notes/perf-v3 list | wc -l)


### PR DESCRIPTION
## Summary
- Removes the TODO comment on line 58 of `test/test_prune.sh` 
- The TODO suggested merging `git perf prune` functionality into the `remove` command
- Created issue #351 to properly track this feature request as it's a substantial enhancement

## Rationale
The TODO comment describes a significant architectural change that deserves:
- Proper discussion and planning
- Community input on the UX design
- Comprehensive implementation across multiple components

Rather than leaving it as an inline TODO, this has been elevated to a tracked issue for better visibility and planning.

## Related
- Closes: (none - only removes TODO)
- See: #351 for the feature request

🤖 Generated with [Claude Code](https://claude.com/claude-code)