### PR TITLE
test: remove outdated TODO comment about write branches cleanup

### DIFF
--- a/test/test_remove.sh
+++ b/test/test_remove.sh
@@ -175,7 +175,6 @@ git perf push
 
 num_measurements=$(git perf report -o - | wc -l)
 # One measurement should be there
-# TODO(kaihowl) clean up of write branches needed
 [[ ${num_measurements} -eq 1 ]] || exit 1
 
 popd


### PR DESCRIPTION
## Summary
- Remove outdated TODO comment in test_remove.sh about write branches cleanup
- The comment is no longer relevant as the test completes successfully without branch cleanup issues

## Test plan
- Verify test_remove.sh still passes (test is functional without the TODO)
- Formatting check with cargo fmt passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)