### PR TITLE
test(remove): verify write branches cleanup after push

### DIFF
--- a/test/test_remove.sh
+++ b/test/test_remove.sh
@@ -177,6 +177,15 @@ num_measurements=$(git perf report -o - | wc -l)
 # One measurement should be there
 [[ ${num_measurements} -eq 1 ]] || exit 1
 
+# Verify that temporary write branches are cleaned up after push
+ref_count=$(git for-each-ref '**/notes/perf-*' | wc -l)
+if [[ 1 -ne $ref_count ]]; then
+  echo "Expected only the permanent git perf ref after push, but found ${ref_count} refs"
+  echo "Current refs:"
+  git for-each-ref '**/notes/perf-*'
+  exit 1
+fi
+
 popd
 
 exit 0


### PR DESCRIPTION
## Summary
- Add verification that temporary write branches (`refs/notes/perf-v3-write-*`) are properly cleaned up after `git perf push`
- Follow the same pattern as `test_tmp_refs_cleaned_up.sh` for consistency
- Implements the verification that was previously requested by the TODO comment removed in PR #352

## Context
The TODO comment at line 178 of `test/test_remove.sh` was removed in PR #352, but the actual verification it requested was not yet implemented. This PR adds that implementation.

After `git perf push`, only the permanent `refs/notes/perf-v3` reference should remain, with all temporary write branches cleaned up. This PR adds explicit verification of that behavior to make the test more robust.

This PR is based on master and contains only the test verification changes.

## Test plan
- Verify the test still passes with the new verification
- Ensure that the ref count check properly validates cleanup behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)