### PR TITLE
test: remove outdated TODO comment in test_prune.sh

### DIFF
--- a/test/test_prune.sh
+++ b/test/test_prune.sh
@@ -3,7 +3,6 @@
 set -e
 set -x
 
-# TODO(kaihowl) add output expectations for report use cases (based on markdown?)
 # TODO(kaihowl) allow pushing to different remotes
 
 script_dir=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)


### PR DESCRIPTION
## Summary
- Removed outdated TODO comment about adding output expectations for report use cases
- The test file `test_prune.sh` only tests the `prune` command and does not include any `git perf report` commands, making this TODO no longer relevant

## Test plan
- [x] Verify test file contains no report commands
- [x] Confirm all existing assertions remain unchanged
- [x] Run cargo fmt --check (passed)
- [x] Run cargo clippy (passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)