### PR TITLE
chore: mark man directory files as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 Cargo.lock linguist-generated=true
 docs/manpage.md linguist-generated=true
+man/** linguist-generated=true


### PR DESCRIPTION
## Summary

- Updates .gitattributes to classify all files under the `man/` directory as linguist-generated
- Extends existing configuration which marks `Cargo.lock` and `docs/manpage.md` as linguist-generated

## Changes

### Configuration
- Modified `.gitattributes` to add the pattern `man/** linguist-generated=true`
  - Ensures that all generated manpage files are excluded from language stats and diff views on GitHub

## Test plan
- Verified `.gitattributes` syntax correctness
- Confirmed that files under `man/` are now recognized as linguist-generated on GitHub UI

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ffa43eff-4eea-4c0d-a6de-4aeb3f0eb779