### PR TITLE
refactor(filter): express measurement filters using subset relation semantics

### DIFF
--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -85,7 +85,9 @@ fn audit(
 ) -> Result<AuditResult> {
     let all = measurement_retrieval::walk_commits(max_count)?;
 
-    let filter_by = |m: &MeasurementData| m.name == measurement && m.matches_key_values(selectors);
+    // Filter using subset relation: selectors ⊆ measurement.key_values
+    let filter_by =
+        |m: &MeasurementData| m.name == measurement && m.key_values_is_superset_of(selectors);
 
     let mut aggregates = measurement_retrieval::take_while_same_epoch(summarize_measurements(
         all,

--- a/git_perf/src/data.rs
+++ b/git_perf/src/data.rs
@@ -32,6 +32,14 @@ impl MeasurementData {
     /// Returns true if all key-value pairs in `criteria` exist in this measurement
     /// with matching values.
     pub fn matches_key_values(&self, criteria: &[(String, String)]) -> bool {
+        self.key_values_is_superset_of(criteria)
+    }
+
+    /// Checks if this measurement's key-values form a superset of the given criteria.
+    /// In other words, verifies that criteria ⊆ measurement.key_values.
+    /// Returns true if all key-value pairs in `criteria` exist in this measurement's
+    /// key_values with matching values.
+    pub fn key_values_is_superset_of(&self, criteria: &[(String, String)]) -> bool {
         criteria
             .iter()
             .all(|(k, v)| self.key_values.get(k).map(|mv| v == mv).unwrap_or(false))

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -376,8 +376,8 @@ pub fn report(
         if !measurement_names.is_empty() && !measurement_names.contains(&m.name) {
             return false;
         }
-        // TODO(kaihowl) express this and the audit-fn equivalent as subset relations
-        m.matches_key_values(key_values)
+        // Filter using subset relation: key_values ⊆ measurement.key_values
+        m.key_values_is_superset_of(key_values)
     };
 
     let relevant_measurements = commits


### PR DESCRIPTION
## Summary

- Introduced `key_values_is_superset_of` method to explicitly express filter logic using subset relation terminology
- Updated both reporting and audit functions to use the new method
- Made the subset relation semantics explicit with mathematical notation (criteria ⊆ measurement.key_values)
- Maintained backward compatibility by keeping `matches_key_values()` as a wrapper

## Changes

- `git_perf/src/data.rs` - Added `key_values_is_superset_of()` method with subset relation semantics
- `git_perf/src/reporting.rs` - Updated filter to use new method
- `git_perf/src/audit.rs` - Updated filter to use new method

## Context

The TODO at `reporting.rs:379` requested expressing the filter logic as subset relations. This PR addresses that by introducing a new method that makes the subset semantics explicit both in naming and documentation, while the reporting and audit functions now use this method to make their intent clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)