### PR TITLE
chore: remove outdated TODO comment in reporting module

### DIFF
--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -452,9 +452,6 @@ pub fn report(
         }
     }
 
-    // TODO(kaihowl) fewer than the -n specified measurements appear in plot (old problem, even in
-    // python)
-
     if output == Path::new("-") {
         match io::stdout().write_all(&plot.as_bytes()) {
             Err(e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),


### PR DESCRIPTION
## Summary
- Remove outdated TODO comment about measurement count in plot (line 455 in reporting.rs)
- The TODO referenced an old known behavior from the Python version where fewer than -n specified measurements appear in the plot
- This behavior is expected and not a bug: measurements may be filtered by name, key-values, or missing from some commits

## Test plan
- [x] Ran `cargo fmt` to format code
- [x] Ran `cargo clippy` to check for linting issues (passed with only warnings)
- [x] Verified the removed TODO was not tracking an actionable issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)