### PR TITLE
feat(cli): add optional remote parameter to push command

### DIFF
--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -103,7 +103,11 @@ pub enum Commands {
     },
 
     /// Publish performance results to remote
-    Push {},
+    Push {
+        /// Remote to push to (defaults to git-perf-origin)
+        #[arg(short, long)]
+        remote: Option<String>,
+    },
 
     /// Pull performance results from remote
     Pull {},

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -80,7 +80,11 @@ Add single measurement
 
 Publish performance results to remote
 
-**Usage:** `git-perf push`
+**Usage:** `git-perf push [OPTIONS]`
+
+###### **Options:**
+
+* `-r`, `--remote <REMOTE>` — Remote to push to (defaults to git-perf-origin)
 
 
 

--- a/git_perf/src/cli.rs
+++ b/git_perf/src/cli.rs
@@ -40,7 +40,7 @@ pub fn handle_calls() -> Result<()> {
         Commands::Add { value, measurement } => {
             add(&measurement.name, value, &measurement.key_value)
         }
-        Commands::Push {} => push(None),
+        Commands::Push { remote } => push(None, remote.as_deref()),
         Commands::Pull {} => pull(None),
         Commands::Report {
             output,

--- a/man/man1/git-perf-push.1
+++ b/man/man1/git-perf-push.1
@@ -4,10 +4,13 @@
 .SH NAME
 push \- Publish performance results to remote
 .SH SYNOPSIS
-\fBpush\fR [\fB\-h\fR|\fB\-\-help\fR] 
+\fBpush\fR [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Publish performance results to remote
 .SH OPTIONS
+.TP
+\fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
+Remote to push to (defaults to git\-perf\-origin)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/test/test_prune.sh
+++ b/test/test_prune.sh
@@ -3,8 +3,6 @@
 set -e
 set -x
 
-# TODO(kaihowl) allow pushing to different remotes
-
 script_dir=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
 # shellcheck source=test/common.sh
 source "$script_dir/common.sh"


### PR DESCRIPTION
## Summary

- Added optional `--remote` (`-r`) parameter to the `push` command to allow users to specify a custom remote
- Default behavior remains unchanged (uses `git-perf-origin` when not specified)
- Resolves TODO comment from test_prune.sh about supporting different remotes

## Changes

- Updated `Push` command in `cli_types/src/lib.rs` to accept optional remote parameter
- Modified `push` function signatures throughout `git_interop.rs` to thread the remote parameter
- Updated all call sites to pass the remote parameter (tests and internal calls)
- Removed completed TODO comment from `test/test_prune.sh`
- Regenerated manpage documentation to reflect the new CLI option

## Test plan

- [x] Code compiles without warnings (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Documentation regenerated (`./scripts/generate-manpages.sh`)
- [ ] Manual testing: `git perf push` (default behavior)
- [ ] Manual testing: `git perf push --remote origin` (custom remote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)