### PR TITLE
chore(ci): update report workflow action reference to use @latest tag

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -54,8 +54,7 @@ jobs:
       - id: install-action-from-release
         if: ${{ inputs.release != 'branch' }}
         name: install git-perf
-        # TODO(kaihowl) move to `latest` once actions are published
-        uses: kaihowl/git-perf/.github/actions/install@master
+        uses: kaihowl/git-perf/.github/actions/install@latest
         with:
           release: latest
       - name: Inject slug/short variables


### PR DESCRIPTION
## Summary
- Removed outdated TODO comment from report workflow
- Updated action reference from `@master` to `@latest` tag

The report workflow previously used `@master` for the git-perf install action reference, with a TODO indicating it should be moved to `@latest` once actions are published. Since the `latest` tag now exists in the repository, this change updates the workflow to use the `@latest` tag as originally intended.

## Test plan
- [ ] Verify CI workflows pass
- [ ] Confirm the workflow uses the correct action reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)