### PR TITLE
chore(ci): remove outdated TODO comment in workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: ci
 
-# TODO(kaihowl) deeper test with merge-based PR workflow (HEAD == merge commit)
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Removed outdated TODO comment from CI workflow file about adding deeper test with merge-based PR workflow
- The CI already includes PR testing functionality on the `pull_request` trigger

## Test plan
- ✅ Verified workflow file syntax is valid
- ✅ No code changes, only comment removal
- ✅ CI will validate workflow on PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)