### PR TITLE
chore(ci): remove outdated TODO comment in workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: ci
 
-# TODO(kaihowl) deeper test with merge-based PR workflow (HEAD == merge commit)
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Removed outdated TODO comment from CI workflow file about adding deeper test with merge-based PR workflow
- The requested functionality **already exists** and has been tested since 2022 via `test/test_pr_merge.sh`
- This test validates that only first-parent commits are considered for merged branches, which is exactly what the TODO requested
- The test runs as part of the standard test suite via `cargo nextest run`

## Context
The TODO comment suggested adding "deeper test with merge-based PR workflow (HEAD == merge commit)". Investigation revealed:
- `test/test_pr_merge.sh` was added in commit 1e05bd3 (2022-04-25) 
- This test creates a merge commit scenario and validates proper first-parent handling
- The test is automatically discovered and run by `test/run_tests.sh` which is called from Rust test suite

## Test plan
- ✅ Verified `test/test_pr_merge.sh` exists and tests merge-based workflows
- ✅ Confirmed test runs via `cargo nextest run` in CI
- ✅ No code changes, only comment removal
- ✅ CI will validate workflow syntax on PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)