### PR TITLE
chore(ci): remove outdated TODO comment about draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,11 +285,6 @@ jobs:
           # List what's left for debugging
           echo "Artifacts after cleanup:"
           ls -la artifacts/
-      # TODO(kaihowl) known race condition:
-      # The release will be created after the tag is created.
-      # release-plz only offers DRAFT but not PRERELEASES.
-      # We cannot upload artifacts to drafts.
-      # Ideally, https://github.com/MarcoIeni/release-plz/issues/1219 is resolved.
       - name: Upload release artifacts
         run: |
           # Find all files in artifacts directory (excluding manifests)


### PR DESCRIPTION
## Summary
- Removed outdated TODO comment in `.github/workflows/release.yml` that referenced a resolved release-plz issue
- The TODO incorrectly stated that artifacts cannot be uploaded to draft releases
- The current workflow successfully uploads artifacts to draft releases using `gh release upload`

## Context
The TODO comment referenced [release-plz issue #1219](https://github.com/MarcoIeni/release-plz/issues/1219), which has been resolved. The issue was about adding prerelease support, which has been implemented.

More importantly, the comment stated "We cannot upload artifacts to drafts", but this is incorrect - the current workflow (since commit f72ebc8) successfully uploads artifacts to draft releases using `gh release upload` command.

## Test plan
- ✅ No code changes, only comment removal
- ✅ CI workflows remain unchanged functionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)