### PR TITLE
chore(test): remove reference to resolved TODO in test file

### DIFF
--- a/test/test_report_no_commits.sh
+++ b/test/test_report_no_commits.sh
@@ -23,8 +23,6 @@ git clone "file://$orig" test_repo
 cd test_repo
 
 # Try to run report on empty repository - should fail with helpful message
-# This test validates the improved error message added to address the TODO
-# about better messaging when git push is missing before shallow clone operations
 output=$(git perf report 2>&1 1>/dev/null) && exit 1
 assert_output_contains "$output" "No commits found in repository" "Missing 'No commits found in repository' in output"
 assert_output_contains "$output" "Ensure commits exist and were pushed to the remote" "Missing guidance about pushing to remote in output"


### PR DESCRIPTION
## Summary
- Removed outdated comment referencing a TODO that has already been addressed
- The test continues to validate the error message behavior for repositories with no commits

## Changes
- Cleaned up comment in `test/test_report_no_commits.sh` that referenced a resolved TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)