### PR TITLE
refactor: resolve clippy warnings for code quality improvements

### DIFF
--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -273,7 +273,7 @@ mod test {
 
         // Create mock data that would produce different z-scores with stddev vs MAD
         let head_value = 35.0;
-        let tail_values = vec![30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 100.0];
+        let tail_values = [30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 100.0];
 
         let head_summary = stats::aggregate_measurements(std::iter::once(&head_value));
         let tail_summary = stats::aggregate_measurements(tail_values.iter());

--- a/git_perf/src/config.rs
+++ b/git_perf/src/config.rs
@@ -243,7 +243,7 @@ mod test {
     /// Initialize a git repository in the given directory
     fn init_git_repo(dir: &Path) {
         std::process::Command::new("git")
-            .args(&["init", "--initial-branch=master"])
+            .args(["init", "--initial-branch=master"])
             .current_dir(dir)
             .output()
             .expect("Failed to initialize git repository");
@@ -256,12 +256,12 @@ mod test {
         // Create a test file and commit it
         fs::write(dir.join("test.txt"), "test content").unwrap();
         std::process::Command::new("git")
-            .args(&["add", "test.txt"])
+            .args(["add", "test.txt"])
             .current_dir(dir)
             .output()
             .expect("Failed to add file");
         std::process::Command::new("git")
-            .args(&["commit", "-m", "test commit"])
+            .args(["commit", "-m", "test commit"])
             .current_dir(dir)
             .output()
             .expect("Failed to commit");

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -251,105 +251,6 @@ impl ReporterFactory {
         res
     }
 }
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_convert_to_x_y_empty() {
-        let reporter = PlotlyReporter::new();
-        let (x, y) = reporter.convert_to_x_y(vec![]);
-        assert!(x.is_empty());
-        assert!(y.is_empty());
-    }
-
-    #[test]
-    fn test_convert_to_x_y_single_value() {
-        let mut reporter = PlotlyReporter::new();
-        reporter.size = 3;
-        let (x, y) = reporter.convert_to_x_y(vec![(0, 1.5)]);
-        assert_eq!(x, vec![2]);
-        assert_eq!(y, vec![1.5]);
-    }
-
-    #[test]
-    fn test_convert_to_x_y_multiple_values() {
-        let mut reporter = PlotlyReporter::new();
-        reporter.size = 5;
-        let (x, y) = reporter.convert_to_x_y(vec![(0, 10.0), (2, 20.0), (4, 30.0)]);
-        assert_eq!(x, vec![4, 2, 0]);
-        assert_eq!(y, vec![10.0, 20.0, 30.0]);
-    }
-
-    #[test]
-    fn test_convert_to_x_y_negative_values() {
-        let mut reporter = PlotlyReporter::new();
-        reporter.size = 2;
-        let (x, y) = reporter.convert_to_x_y(vec![(0, -5.5), (1, -10.2)]);
-        assert_eq!(x, vec![1, 0]);
-        assert_eq!(y, vec![-5.5, -10.2]);
-    }
-
-    #[test]
-    fn test_plotly_reporter_as_bytes_not_empty() {
-        let reporter = PlotlyReporter::new();
-        let bytes = reporter.as_bytes();
-        assert!(!bytes.is_empty());
-        // HTML output should contain plotly-related content
-        let html = String::from_utf8_lossy(&bytes);
-        assert!(html.contains("plotly") || html.contains("Plotly"));
-    }
-
-    #[test]
-    fn test_reporter_factory_html_extension() {
-        let path = Path::new("output.html");
-        let reporter = ReporterFactory::from_file_name(path);
-        assert!(reporter.is_some());
-    }
-
-    #[test]
-    fn test_reporter_factory_csv_extension() {
-        let path = Path::new("output.csv");
-        let reporter = ReporterFactory::from_file_name(path);
-        assert!(reporter.is_some());
-    }
-
-    #[test]
-    fn test_reporter_factory_stdout() {
-        let path = Path::new("-");
-        let reporter = ReporterFactory::from_file_name(path);
-        assert!(reporter.is_some());
-    }
-
-    #[test]
-    fn test_reporter_factory_unsupported_extension() {
-        let path = Path::new("output.txt");
-        let reporter = ReporterFactory::from_file_name(path);
-        assert!(reporter.is_none());
-    }
-
-    #[test]
-    fn test_reporter_factory_no_extension() {
-        let path = Path::new("output");
-        let reporter = ReporterFactory::from_file_name(path);
-        assert!(reporter.is_none());
-    }
-
-    #[test]
-    fn test_reporter_factory_uppercase_extension() {
-        let path = Path::new("output.HTML");
-        let reporter = ReporterFactory::from_file_name(path);
-        assert!(reporter.is_some());
-    }
-
-    #[test]
-    fn test_csv_reporter_as_bytes_empty_on_init() {
-        let reporter = CsvReporter::new();
-        let bytes = reporter.as_bytes();
-        // Empty reporter should produce empty bytes
-        assert!(bytes.is_empty() || String::from_utf8_lossy(&bytes).trim().is_empty());
-    }
-}
 
 pub fn report(
     output: PathBuf,
@@ -462,4 +363,104 @@ pub fn report(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_to_x_y_empty() {
+        let reporter = PlotlyReporter::new();
+        let (x, y) = reporter.convert_to_x_y(vec![]);
+        assert!(x.is_empty());
+        assert!(y.is_empty());
+    }
+
+    #[test]
+    fn test_convert_to_x_y_single_value() {
+        let mut reporter = PlotlyReporter::new();
+        reporter.size = 3;
+        let (x, y) = reporter.convert_to_x_y(vec![(0, 1.5)]);
+        assert_eq!(x, vec![2]);
+        assert_eq!(y, vec![1.5]);
+    }
+
+    #[test]
+    fn test_convert_to_x_y_multiple_values() {
+        let mut reporter = PlotlyReporter::new();
+        reporter.size = 5;
+        let (x, y) = reporter.convert_to_x_y(vec![(0, 10.0), (2, 20.0), (4, 30.0)]);
+        assert_eq!(x, vec![4, 2, 0]);
+        assert_eq!(y, vec![10.0, 20.0, 30.0]);
+    }
+
+    #[test]
+    fn test_convert_to_x_y_negative_values() {
+        let mut reporter = PlotlyReporter::new();
+        reporter.size = 2;
+        let (x, y) = reporter.convert_to_x_y(vec![(0, -5.5), (1, -10.2)]);
+        assert_eq!(x, vec![1, 0]);
+        assert_eq!(y, vec![-5.5, -10.2]);
+    }
+
+    #[test]
+    fn test_plotly_reporter_as_bytes_not_empty() {
+        let reporter = PlotlyReporter::new();
+        let bytes = reporter.as_bytes();
+        assert!(!bytes.is_empty());
+        // HTML output should contain plotly-related content
+        let html = String::from_utf8_lossy(&bytes);
+        assert!(html.contains("plotly") || html.contains("Plotly"));
+    }
+
+    #[test]
+    fn test_reporter_factory_html_extension() {
+        let path = Path::new("output.html");
+        let reporter = ReporterFactory::from_file_name(path);
+        assert!(reporter.is_some());
+    }
+
+    #[test]
+    fn test_reporter_factory_csv_extension() {
+        let path = Path::new("output.csv");
+        let reporter = ReporterFactory::from_file_name(path);
+        assert!(reporter.is_some());
+    }
+
+    #[test]
+    fn test_reporter_factory_stdout() {
+        let path = Path::new("-");
+        let reporter = ReporterFactory::from_file_name(path);
+        assert!(reporter.is_some());
+    }
+
+    #[test]
+    fn test_reporter_factory_unsupported_extension() {
+        let path = Path::new("output.txt");
+        let reporter = ReporterFactory::from_file_name(path);
+        assert!(reporter.is_none());
+    }
+
+    #[test]
+    fn test_reporter_factory_no_extension() {
+        let path = Path::new("output");
+        let reporter = ReporterFactory::from_file_name(path);
+        assert!(reporter.is_none());
+    }
+
+    #[test]
+    fn test_reporter_factory_uppercase_extension() {
+        let path = Path::new("output.HTML");
+        let reporter = ReporterFactory::from_file_name(path);
+        assert!(reporter.is_some());
+    }
+
+    #[test]
+    fn test_csv_reporter_as_bytes_empty_on_init() {
+        let reporter = CsvReporter::new();
+        let bytes = reporter.as_bytes();
+        // Empty reporter should produce empty bytes
+        assert!(bytes.is_empty() || String::from_utf8_lossy(&bytes).trim().is_empty());
+    }
 }

--- a/git_perf/src/stats.rs
+++ b/git_perf/src/stats.rs
@@ -175,7 +175,7 @@ mod test {
 
     #[test]
     fn single_measurement() {
-        let measurements = vec![1.0];
+        let measurements = [1.0];
         let stats = aggregate_measurements(measurements.iter());
         assert_eq!(stats.len, 1);
         assert_eq!(stats.mean, 1.0);
@@ -184,7 +184,7 @@ mod test {
 
     #[test]
     fn no_measurement() {
-        let measurements = vec![];
+        let measurements = [];
         let stats = aggregate_measurements(measurements.iter());
         assert_eq!(stats.len, 0);
         assert_eq!(stats.mean, 0.0);
@@ -321,7 +321,7 @@ mod test {
 
     #[test]
     fn test_mad_in_aggregate_measurements() {
-        let measurements = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let measurements = [1.0, 2.0, 3.0, 4.0, 5.0];
         let stats = aggregate_measurements(measurements.iter());
 
         assert_eq!(stats.len, 5);

--- a/git_perf/tests/manpage_tests.rs
+++ b/git_perf/tests/manpage_tests.rs
@@ -52,12 +52,10 @@ fn find_man_dir() -> PathBuf {
             // Check if it contains at least one manpage
             if let Ok(entries) = std::fs::read_dir(path) {
                 let mut has_manpages = false;
-                for entry in entries {
-                    if let Ok(entry) = entry {
-                        if entry.path().extension().map_or(false, |ext| ext == "1") {
-                            has_manpages = true;
-                            break;
-                        }
+                for entry in entries.flatten() {
+                    if entry.path().extension().is_some_and(|ext| ext == "1") {
+                        has_manpages = true;
+                        break;
                     }
                 }
                 if has_manpages {
@@ -122,7 +120,7 @@ fn test_manpage_generation() {
         );
 
         // Basic content validation - check that the file is not empty
-        let content = std::fs::read_to_string(&page_path)
+        let content = std::fs::read_to_string(page_path)
             .unwrap_or_else(|_| panic!("Failed to read manpage: {}", page_path.display()));
 
         assert!(


### PR DESCRIPTION
## Summary

This PR resolves multiple clippy warnings to improve code quality and maintainability:

- **manpage_tests.rs**: Changed `map_or(false, ...)` to `is_some_and(...)` for clearer intent
- **manpage_tests.rs & config.rs**: Removed unnecessary reference borrows (needless_borrows_for_generic_args)
- **audit.rs & stats.rs**: Replaced `vec!` with array literals in test code for efficiency (useless_vec)
- **reporting.rs**: Moved `report` function before test module to follow clippy item ordering conventions
- **manpage_tests.rs**: Used `flatten()` to simplify iterator handling (manual_flatten)

All clippy warnings now pass with `-D warnings` flag.

## Test plan

- [x] Ran `cargo fmt` to ensure code formatting
- [x] Ran `cargo clippy --all-targets --all-features -- -D warnings` - all warnings resolved
- [x] Verified no functional changes - all modifications are clippy-recommended code improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)