### PR TITLE
fix(ci): install cargo-nextest in slow test loop workflow

### DIFF
--- a/.github/workflows/slow-test-loop.yml
+++ b/.github/workflows/slow-test-loop.yml
@@ -39,6 +39,9 @@ jobs:
       with:
         toolchain: stable
 
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+
     - name: Build git-perf
       run: cargo build --verbose
 


### PR DESCRIPTION
## Summary

- Added missing `cargo-nextest` installation step to the slow-test-loop workflow
- The workflow was failing because it tried to run `cargo nextest run` without installing nextest first
- Used the same installation method (`taiki-e/install-action@nextest`) as other workflows in the repository

## Test plan

- [ ] Verify the workflow runs successfully with nextest installed
- [ ] Confirm the slow test loop can execute multiple iterations
- [ ] Check that test failures are properly detected and reported

Fixes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)