### PR TITLE
fix(ci): exclude unviable mutations from mutation score calculation

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -213,8 +213,15 @@ jobs:
         if [ "$total_mutants" != "null" ] && [ "$total_mutants" != "0" ] && [ -n "$total_mutants" ] && [ "$total_mutants" -gt 0 ] 2>/dev/null; then
           # Calculate mutation score if we have valid numbers
           if [ "$caught_mutants" != "null" ] && [ -n "$caught_mutants" ]; then
-            score=$(echo "scale=2; $caught_mutants * 100 / $total_mutants" | bc -l 2>/dev/null || echo "N/A")
+            # Exclude unviable mutations from scoring (unviable mutations don't compile/can't be tested)
+            viable_mutants=$(echo "$total_mutants - $unviable_mutants" | bc -l 2>/dev/null || echo "$total_mutants")
+            if [ "$viable_mutants" -gt 0 ] 2>/dev/null; then
+              score=$(echo "scale=2; $caught_mutants * 100 / $viable_mutants" | bc -l 2>/dev/null || echo "N/A")
+            else
+              score="N/A"
+            fi
             echo "- **Total Mutants:** $total_mutants" >> mutation-summary.md
+            echo "- **Viable Mutants:** $viable_mutants" >> mutation-summary.md
             echo "- **Caught:** $caught_mutants" >> mutation-summary.md
             echo "- **Missed:** $missed_mutants" >> mutation-summary.md
             echo "- **Timeout:** $timeout_mutants" >> mutation-summary.md


### PR DESCRIPTION
## Summary

This PR fixes issue #386 by excluding unviable mutations from the mutation score calculation in the weekly mutation testing workflow.

**What are unviable mutations?**
Unviable mutations are those that don't compile or cannot be tested. Including them in the mutation score calculation artificially deflates the score and doesn't provide an accurate measure of test quality.

**Changes:**
- Calculate `viable_mutants = total_mutants - unviable_mutants`
- Update mutation score calculation to use `viable_mutants` instead of `total_mutants`
- Add "Viable Mutants" line to the mutation summary report for transparency

**Impact:**
Based on the most recent mutation testing run (Oct 5, 2025):
- **Old score:** 297/342 = 86.84%
- **New score:** 297/(342-23) = 297/319 = **93.10%**

This provides a more accurate representation of test coverage quality by focusing only on mutations that are actually testable.

## Test plan
- [x] Code changes reviewed
- [x] Manual calculation verified (297/319 = 93.10%)
- [x] Workflow logic tested for edge cases (viable_mutants > 0 check)
- [ ] Will be validated in next mutation testing workflow run

Fixes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)