### PR TITLE
fix(ci): convert test-measure2 to 1s sleep with new epoch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           set -x
           cargo install --path git_perf
           # Run report on repo with known (n=10) number of measurements
-          git perf measure -n 10 -m test-measure2 -k os=${{matrix.os}} -k rust=${{matrix.rust}} -- sleep 0.01
+          git perf measure -n 10 -m test-measure2 -k os=${{matrix.os}} -k rust=${{matrix.rust}} -- sleep 1
           git perf measure -n 10 -m report -k os=${{matrix.os}} -k rust=${{matrix.rust}} -- git perf report -n 1 -o report.html
           git perf add -m report-size -k os=${{matrix.os}} -k rust=${{matrix.rust}} $(wc -c < report.html)
           git perf push

--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -6,4 +6,5 @@ min_relative_deviation = 10.0
 epoch = "fe6d0205"
 
 [measurement."test-measure2"]
-epoch = "b5f56987"
+epoch = "bd5554eb"
+min_relative_deviation = 10.0


### PR DESCRIPTION
## Summary

- Convert test-measure2 from measuring `sleep 0.01` (10ms) to `sleep 1` (1 second)
- Add 10% tolerance (`min_relative_deviation = 10.0`) to allow acceptable variance
- Bump epoch to `bd5554eb` to establish new measurement baseline

## Motivation

Subsecond sleep measurements were producing inconsistent and unreliable results due to:
- System scheduler granularity (typically 1-10ms on Linux)
- Process startup/shutdown overhead
- Timer resolution limitations
- CPU frequency scaling effects

These factors caused high variance in measurements, making performance regression detection unreliable for such short durations.

## Changes

1. **CI workflow**: Updated `.github/workflows/ci.yml` to measure `sleep 1` instead of `sleep 0.01`
2. **Config**: Added `min_relative_deviation = 10.0` to test-measure2 configuration
3. **Epoch**: Bumped epoch to current HEAD (`bd5554eb`) to start fresh baseline

The 1-second sleep provides more stable measurements while still completing quickly in CI, and the 10% tolerance accounts for normal system variance.

## Test Plan

- ✅ Changes compile and pass local validation
- ✅ Conventional commit format verified
- ✅ CI will run with new measurement configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)