### PR TITLE
fix(ci): generate docs in OUT_DIR and add publish-check workflow to validate cargo publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,17 +147,20 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-    - name: Check documentation is up to date
+    - name: Generate documentation
       run: |
         ./scripts/generate-manpages.sh
-
-    - name: Upload documentation patch artifacts
-      uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: documentation-patches
-        path: /tmp/*.diff
-        if-no-files-found: error
+    - name: Check for uncommitted changes
+      run: |
+        if ! git diff --exit-code man/ docs/; then
+          echo "Error: Documentation is out of date!"
+          echo "Please run './scripts/generate-manpages.sh' and commit the changes."
+          echo ""
+          echo "Diff:"
+          git diff man/ docs/
+          exit 1
+        fi
+        echo "Documentation is up to date ✓"
 
   report:
     name: git-perf

--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -1,0 +1,37 @@
+name: Publish Check
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  publish-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check cargo publish (dry-run)
+        run: |
+          cargo publish --dry-run --package git-perf --allow-dirty
+          cargo publish --dry-run --package git_perf_cli_types --allow-dirty

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,3 +21,8 @@ install-path = "CARGO_HOME"
 install-updater = false
 # Where to host releases
 hosting = "github"
+# Extra artifacts to include in release archives
+extra-artifacts = [
+  "man/man1/*.1",
+  "docs/manpage.md"
+]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,8 +21,21 @@ install-path = "CARGO_HOME"
 install-updater = false
 # Where to host releases
 hosting = "github"
+
 # Extra artifacts to include in release archives
-extra-artifacts = [
-  "man/man1/*.1",
+[[dist.extra-artifacts]]
+artifacts = [
+  "man/man1/git-perf.1",
+  "man/man1/git-perf-add.1",
+  "man/man1/git-perf-audit.1",
+  "man/man1/git-perf-bump-epoch.1",
+  "man/man1/git-perf-list-commits.1",
+  "man/man1/git-perf-measure.1",
+  "man/man1/git-perf-prune.1",
+  "man/man1/git-perf-pull.1",
+  "man/man1/git-perf-push.1",
+  "man/man1/git-perf-remove.1",
+  "man/man1/git-perf-report.1",
   "docs/manpage.md"
 ]
+build = ["./scripts/generate-manpages.sh"]

--- a/git_perf/build.rs
+++ b/git_perf/build.rs
@@ -5,12 +5,9 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
-    // Version normalization is no longer needed since manpages exclude version entirely
-
-    // Path calculation to the workspace root
-    let workspace_root = out_dir.join("../../../../../");
-    let man_dir = workspace_root.join("man").join("man1");
-    let docs_dir = workspace_root.join("docs");
+    // Generate manpages and docs in OUT_DIR to comply with cargo publish rules
+    let man_dir = out_dir.join("man").join("man1");
+    let docs_dir = out_dir.join("docs");
 
     fs::create_dir_all(&man_dir).unwrap();
     fs::create_dir_all(&docs_dir).unwrap();

--- a/scripts/generate-manpages.sh
+++ b/scripts/generate-manpages.sh
@@ -1,49 +1,43 @@
 #!/bin/bash
 
 # Script to generate manpages and markdown documentation
-# Manpages are generated without version information to avoid version-based diffs
+# Generates docs in OUT_DIR (cargo publish compliant), then copies to repo for version control
 
 set -e
 
 echo "Generating manpages and markdown documentation (manpages without version)"
 
-# Check that the generated files exist
+# Build to generate docs in OUT_DIR
+cargo build --package git_perf_cli_types --package git-perf
+
+# Find the OUT_DIR by looking for the generated files
+OUT_DIR=$(find target/debug/build/git-perf-*/out -type d 2>/dev/null | head -n 1)
+
+if [[ -z "$OUT_DIR" ]]; then
+  echo "Error: Could not find OUT_DIR in target/debug/build/git-perf-*/out"
+  exit 1
+fi
+
+echo "Found generated docs in: $OUT_DIR"
+
+# Ensure the repository directories exist
+mkdir -p man/man1
+mkdir -p docs
+
+# Copy generated files from OUT_DIR to repository
+cp -r "$OUT_DIR/man/man1/"*.1 man/man1/
+cp "$OUT_DIR/docs/manpage.md" docs/manpage.md
+
+echo "✓ Manpages and documentation copied to repository"
+
+# Validate that files were copied successfully
 if [[ ! -f "docs/manpage.md" ]]; then
-  echo "Error: Generated markdown documentation not found at docs/manpage.md"
+  echo "Error: Failed to copy markdown documentation to docs/manpage.md"
   exit 1
 fi
 if [[ ! -f "man/man1/git-perf.1" ]]; then
-  echo "Error: Generated manpage not found at man/man1/git-perf.1"
+  echo "Error: Failed to copy manpage to man/man1/git-perf.1"
   exit 1
 fi
 
-# Create backups of the original files for comparison
-cp docs/manpage.md /tmp/original_markdown.md
-cp man/man1/git-perf.1 /tmp/original_manpage.1
-
-# Generate manpages and markdown documentation
-cargo build --package git_perf_cli_types --package git-perf
-
-# Compare markdown documentation
-if ! diff -u /tmp/original_markdown.md docs/manpage.md > /tmp/markdown.diff; then
-  echo "Error: Markdown documentation is out of date. A patch file has been created at /tmp/markdown.diff"
-  echo ""
-  echo "To fix this, run:"
-  echo "   ./scripts/generate-manpages.sh"
-  echo ""
-  echo "The markdown documentation is automatically generated during the build process using clap_markdown."
-  exit 1
-fi
-echo "Markdown documentation is up to date ✓"
-
-# Compare manpage documentation
-if ! diff -u /tmp/original_manpage.1 man/man1/git-perf.1 > /tmp/manpage.diff; then
-  echo "Error: Manpage documentation is out of date. A patch file has been created at /tmp/manpage.diff"
-  echo ""
-  echo "To fix this, run:"
-  echo "   ./scripts/generate-manpages.sh"
-  echo ""
-  echo "The manpage documentation is automatically generated during the build process using clap_mangen."
-  exit 1
-fi
-echo "Manpage documentation is up to date ✓"
+echo "✓ Documentation generation complete"


### PR DESCRIPTION
## Summary

Fixes the cargo publish failure caused by build.rs modifying files outside of OUT_DIR, which Cargo prohibits during publishing. Adds a new GitHub workflow to check `cargo publish --dry-run` on PRs to prevent regressions.

## Changes

- **build.rs**: Updated to generate manpages and markdown docs only in OUT_DIR
- **generate-manpages.sh**: Modified to copy generated docs from OUT_DIR to repository for version control
- **.github/workflows/ci.yml**: Enhanced to generate docs and fail if the committed docs are out of date
- **.github/workflows/publish-check.yml**: New workflow added to run `cargo publish --dry-run` on PRs to master
- **dist-workspace.toml**: Added manpages and docs as extra artifacts for cargo-dist releases

## Test Plan

- [x] `cargo build` successfully generates docs in OUT_DIR
- [x] `cargo publish --dry-run --allow-dirty` completes successfully (no longer fails with "build.rs modified files" error)
- [x] CI workflow fails if documentation is out of date
- [x] New publish-check.yml workflow validates publishing on future PRs
- [x] `cargo fmt` passes

## Additional Context

This resolves the CI failure where cargo publish was rejecting the package because build.rs wrote directly to the repository's `man/` and `docs/` directories. The new approach:

1. Generates docs in OUT_DIR during normal builds (cargo publish compliant)
2. Uses generate-manpages.sh script to copy from OUT_DIR to repo for version control
3. Includes docs in release tarballs via cargo-dist extra-artifacts
4. Validates publishing in CI with a dedicated publish-check workflow to catch issues early

Additionally, the main CI workflow now checks that committed documentation matches generated output, preventing drift in docs.

📎 **Task**: https://www.terragonlabs.com/task/c7a761b6-80eb-46d6-9934-3d05fc6423a4