### PR TITLE
ci(publish): improve workspace validation with auto-versioning

### DIFF
--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -31,7 +31,30 @@ jobs:
           path: target
           key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Set non-existent versions for workspace packages
+        run: |
+          # Generate a unique version based on timestamp to ensure it doesn't exist on crates.io
+          TEMP_VERSION="999.999.$(date +%s)"
+          echo "Using temporary version: $TEMP_VERSION"
+
+          # Update all workspace package versions
+          for manifest in cli_types/Cargo.toml git_perf/Cargo.toml; do
+            if [ -f "$manifest" ]; then
+              sed -i "s/^version = \".*\"/version = \"$TEMP_VERSION\"/" "$manifest"
+            fi
+          done
+
+          # Update all workspace dependencies to use the new version
+          for manifest in cli_types/Cargo.toml git_perf/Cargo.toml; do
+            if [ -f "$manifest" ]; then
+              sed -i "s/git_perf_cli_types = { version = \"[^\"]*\"/git_perf_cli_types = { version = \"$TEMP_VERSION\"/" "$manifest"
+            fi
+          done
+
+          echo "Updated package versions:"
+          grep -H '^version = ' cli_types/Cargo.toml git_perf/Cargo.toml || true
+          grep -H 'git_perf_cli_types = { version' git_perf/Cargo.toml || true
+
       - name: Check cargo publish (dry-run)
         run: |
-          cargo publish --dry-run --package git-perf --allow-dirty
-          cargo publish --dry-run --package git_perf_cli_types --allow-dirty
+          cargo publish --workspace --dry-run --allow-dirty


### PR DESCRIPTION
## Summary

Improves the publish-check workflow to properly validate interdependent changes across workspace packages (`cli_types` and `git_perf`) without requiring manual version bumps.

## Problem

Previously, the workflow validated each package separately using `cargo publish --dry-run --package <name>`. This approach had a critical limitation: when validating `git_perf`, cargo would resolve the `git_perf_cli_types` dependency from crates.io rather than using the local workspace version. This meant that interdependent changes across both packages would fail validation even if they were correct.

## Solution

The workflow now:

1. **Uses nightly toolchain**: Required for workspace publishing features (stabilized in Rust 1.89)
2. **Auto-generates temporary versions**: Sets all package versions to `999.999.<timestamp>` before validation
3. **Validates entire workspace**: Uses `cargo publish --workspace --dry-run --allow-dirty` to validate all packages together

## Why Auto-Versioning?

When cargo packages workspace members, it resolves dependencies by version. If a version exists on crates.io, cargo uses that published version during verification. By setting a non-existent version (`999.999.<timestamp>`), we force cargo to use the local workspace versions with all interdependent changes.

Benefits:
- ✅ Validates cross-package changes correctly
- ✅ No manual version bumps needed for CI
- ✅ Uses actual workspace state with interdependent modifications
- ✅ Unique version per run (timestamp-based)

## Test Plan

- [x] Workflow passes with interdependent changes across packages
- [x] Workflow correctly validates workspace packaging
- [x] Version replacement works for all manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)