### PR TITLE
fix(audit): handle NaN safely in direction arrow computation

### DIFF
--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -24,11 +24,12 @@ fn format_z_score_display(z_score: f64) -> String {
 
 /// Determines the direction arrow based on comparison of head and tail means.
 /// Returns ↑ for greater, ↓ for less, → for equal.
+/// Returns → for NaN values to avoid panicking.
 fn get_direction_arrow(head_mean: f64, tail_mean: f64) -> &'static str {
-    match head_mean.partial_cmp(&tail_mean).unwrap() {
-        Ordering::Greater => "↑",
-        Ordering::Less => "↓",
-        Ordering::Equal => "→",
+    match head_mean.partial_cmp(&tail_mean) {
+        Some(Ordering::Greater) => "↑",
+        Some(Ordering::Less) => "↓",
+        Some(Ordering::Equal) | None => "→",
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixed unsafe `unwrap()` call on `partial_cmp` in `get_direction_arrow` function
- Prevents potential panic when comparing NaN values in audit output
- Returns → arrow for NaN values to handle edge cases gracefully

## Changes

### Bug Fix
- Removed `.unwrap()` on `partial_cmp` result in `get_direction_arrow` function (git_perf/src/audit.rs:28)
- Changed pattern matching to handle `Option<Ordering>` properly
- Maps `None` (NaN comparison) to → arrow, same as `Equal`

### Documentation
- Updated function doc comment to clarify NaN handling behavior

## Technical Details

The `partial_cmp` method on `f64` returns `None` when either operand is NaN. The original code used `.unwrap()` which would panic in this case. The fix properly handles all cases:
- `Some(Ordering::Greater)` → ↑
- `Some(Ordering::Less)` → ↓  
- `Some(Ordering::Equal)` or `None` → →

## Test plan
- [x] Code compiles successfully with `cargo check`
- [x] Existing tests in `test_direction_arrows` validate normal comparison cases
- [x] NaN values now handled safely without panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>