### PR TITLE
feat(config): add measurement unit configuration support (phase 1)

### DIFF
--- a/docs/example_config.toml
+++ b/docs/example_config.toml
@@ -9,14 +9,20 @@
         # The relative deviation is calculated as: |(head_value / tail_median - 1.0) * 100%|
         # where tail_median is the median of historical measurements (excluding HEAD)
         min_relative_deviation = 5.0
-        
+
         # Statistical dispersion method for outlier detection
         # Options: "stddev" (standard deviation) or "mad" (median absolute deviation)
         # MAD is more robust to outliers, stddev is more sensitive
         dispersion_method = "mad"
-        
+
         # Default epoch for accepting performance changes (hex format)
         epoch = "00000000"
+
+        # Default unit for all measurements (optional)
+        # If set, this unit will be displayed in reports, audit output, and CSV exports
+        # for all measurements that don't have a specific unit configured
+        # Common units: "ms", "seconds", "bytes", "MB", "requests/sec", etc.
+        # unit = "ms"
 
 # Measurement-specific settings (override parent defaults)
 [measurement."build_time"]
@@ -25,6 +31,7 @@
 min_relative_deviation = 10.0
 dispersion_method = "mad"
 epoch = "12345678"
+unit = "ms"  # Display build time in milliseconds
 
 [measurement."memory_usage"]
 # Memory usage should be more stable, so use a lower threshold
@@ -32,22 +39,26 @@ epoch = "12345678"
 min_relative_deviation = 2.0
 dispersion_method = "stddev"
 epoch = "abcdef12"
+unit = "bytes"  # Display memory usage in bytes
 
 [measurement."test_runtime"]
 # Test runtime can vary significantly, use a moderate threshold
 # Use MAD for test times as they can have outliers from system performance
 min_relative_deviation = 7.5
 dispersion_method = "mad"
+unit = "seconds"  # Display test runtime in seconds
 
 [measurement."cpu_usage"]
 # CPU usage measurements - use stddev for more sensitive detection
 min_relative_deviation = 3.0
 dispersion_method = "stddev"
+unit = "%"  # Display CPU usage as percentage
 
 [measurement."network_latency"]
 # Network latency can have spikes, use MAD for robustness
 min_relative_deviation = 8.0
 dispersion_method = "mad"
+unit = "ms"  # Display network latency in milliseconds
 
 # Backoff settings for retry logic
 [backoff]


### PR DESCRIPTION
## Summary
- Implements phase one of measurement units support
- Introduces measurement_unit(measurement) to fetch the configured unit for a measurement
- Adds global/default unit capability and per-measurement overrides
- Adds tests covering precedence and fallbacks

## Changes

### Core
- Add measurement_unit(measurement: &str) -> Option<String> in git_perf/src/config.rs
  - Reads the hierarchical config and returns the value of the unit for the given measurement
  - Supports a parent default (global measurement unit) as a fallback when a measurement-specific unit is present
  - Honors per-measurement unit overrides over the parent default
  - Returns None when no unit is configured anywhere

### Config & Documentation
- Update docs/example_config.toml to demonstrate global default unit and per-measurement unit settings
  - Includes optional global unit and unit fields under [measurement."<name>"] blocks
  - Example units: ms, bytes, seconds, %, etc.

### Tests
- Extend tests in git_perf/src/config.rs to validate unit handling
  - test_measurement_unit: per-measurement units with parent default fallback
  - test_measurement_unit_precedence: per-measurement unit overrides parent default
  - test_measurement_unit_no_parent_default: behavior when there is no parent default

## Test Plan
- Run cargo test to verify new unit-related behavior
- Validate with sample workspace config (.gitperfconfig) as exercised by tests

## Notes
- This is phase 1 of measurement units support. Future phases will integrate units into reports, audit output, and CSV exports, ensuring units are displayed consistently across all outputs.
- Behavior: if no unit is configured for a measurement and no global default exists, measurement_unit(...) returns None. 

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8e1954f7-cc4b-49e4-a5d1-1060f4785185