### PR TITLE
chore: add unit fields to .gitperfconfig measurements

### DIFF
--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -1,13 +1,17 @@
 [measurement."report-size"]
 epoch = "439374ca"
 min_relative_deviation = 10.0
+unit = "bytes"
 
 [measurement."report"]
 epoch = "439374ca"
+unit = "ms"
 
 [measurement."test-measure2"]
 epoch = "439374ca"
 min_relative_deviation = 10.0
+unit = "ms"
 
 [measurement."release-binary-size"]
 epoch = "c692cdd"
+unit = "bytes"


### PR DESCRIPTION
## Summary
- Adds explicit unit fields to measurement configurations in `.gitperfconfig`
- Completes Phase 1 implementation of measurement units support
- Enables unit display in audit output, reports, and CSV exports

## Changes

### Configuration Updates
- `.gitperfconfig`:
  - `[measurement."report-size"]`: unit = "bytes"
  - `[measurement."report"]`: unit = "ms"
  - `[measurement."test-measure2"]`: unit = "ms"
  - `[measurement."release-binary-size"]`: unit = "bytes"

## Rationale
- Provides semantic clarity for measurement values in all output formats
- Follows measurement units support plan (docs/plans/measurement-units-support.md)
- Enables consistent unit display across audit, reports, and exports
- Maintains backward compatibility (units are optional)

## Test Plan
- [x] Validate configuration parses correctly with new unit fields
- [x] Verify measurements display with specified units in audit output
- [x] Ensure CI/build passes with updated configuration

## Related
- Related to measurement units support implementation (Phase 1-2 completed)
- Configuration follows example_config.toml pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>