### PR TITLE
fix(config): correct measurement units from ms to ns for time-based measurements

### DIFF
--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -5,12 +5,12 @@ unit = "bytes"
 
 [measurement."report"]
 epoch = "439374ca"
-unit = "ms"
+unit = "ns"
 
 [measurement."test-measure2"]
 epoch = "439374ca"
 min_relative_deviation = 10.0
-unit = "ms"
+unit = "ns"
 
 [measurement."release-binary-size"]
 epoch = "c692cdd"


### PR DESCRIPTION
## Summary

Fixes incorrect unit configuration in `.gitperfconfig` for time-based measurements. The `git perf measure` command stores time measurements in **nanoseconds** (using `duration.as_nanos()` in `basic_measure.rs:31`), but the config file incorrectly specified the unit as "ms" (milliseconds).

## Changes

- Changed `unit = "ms"` to `unit = "ns"` for `measurement."report"`
- Changed `unit = "ms"` to `unit = "ns"` for `measurement."test-measure2"`
- Verified that `measurement."report-size"` and `measurement."release-binary-size"` correctly use `unit = "bytes"` (they use `git perf add` with byte counts)

## Root Cause

The `basic_measure.rs` file uses `duration.as_nanos()` to store time measurements, resulting in nanosecond precision. The configuration must match this actual storage unit.

## Test Plan

- [x] Verified code at `git_perf/src/basic_measure.rs:31` uses `duration.as_nanos()`
- [x] Checked all measurement usages in `.github/workflows/ci.yml`
- [x] Confirmed `report` and `test-measure2` use `git perf measure` (stores ns)
- [x] Confirmed `report-size` and `release-binary-size` use `git perf add` with byte values
- [x] Ran `cargo fmt` and `cargo clippy` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)