### PR TITLE
feat: CSV header and unit column in long-format export

### DIFF
--- a/test/test_conflict_init.sh
+++ b/test/test_conflict_init.sh
@@ -55,8 +55,9 @@ pushd "$myworkrepo"
 
 git perf pull
 num_measurements=$(git perf report -o -  | wc -l)
-if [[ $num_measurements -ne 2 ]]; then
-  echo "Expected two measurements, but only have these:"
+# CSV now includes header row, so 2 measurements + 1 header = 3 lines
+if [[ $num_measurements -ne 3 ]]; then
+  echo "Expected two measurements (3 lines with header), but have $num_measurements lines:"
   git perf report -o -
   exit 1
 fi

--- a/test/test_pushpull_conflict.sh
+++ b/test/test_pushpull_conflict.sh
@@ -68,14 +68,16 @@ pushd repo2
 git perf push
 git perf report -o -
 num_measurements=$(git perf report -o - | wc -l)
-[[ ${num_measurements} -eq 3 ]] || exit 1
+# CSV now includes header row, so 3 measurements + 1 header = 4 lines
+[[ ${num_measurements} -eq 4 ]] || exit 1
 popd
 
 echo In the first working copy, we should see all three measurements now
 pushd repo1
 git perf pull
 num_measurements=$(git perf report -o - | wc -l)
-[[ ${num_measurements} -eq 3 ]] || exit 1
+# CSV now includes header row, so 3 measurements + 1 header = 4 lines
+[[ ${num_measurements} -eq 4 ]] || exit 1
 popd
 
 echo ---- Test case 2: No conflicts but merge needed.
@@ -97,12 +99,14 @@ git pull
 create_commit
 git perf add -m echo 0.5 -k repo=second
 num_measurements=$(git perf report -o - | wc -l)
-[[ ${num_measurements} -eq 1 ]] || exit 1
+# CSV now includes header row, so 1 measurement + 1 header = 2 lines
+[[ ${num_measurements} -eq 2 ]] || exit 1
 git push
 # There is a conflict, it should automatically pull first
 git perf push
 num_measurements=$(git perf report -o - | wc -l)
-[[ ${num_measurements} -eq 2 ]] || exit 1
+# CSV now includes header row, so 2 measurements + 1 header = 3 lines
+[[ ${num_measurements} -eq 3 ]] || exit 1
 popd
 
 echo In the first working copy, we should also see both measurements on separate commits now
@@ -110,7 +114,8 @@ pushd repo1
 git pull
 git perf pull
 num_measurements=$(git perf report -o - | wc -l)
-[[ ${num_measurements} -eq 2 ]] || exit 1
+# CSV now includes header row, so 2 measurements + 1 header = 3 lines
+[[ ${num_measurements} -eq 3 ]] || exit 1
 popd
 
 

--- a/test/test_remove.sh
+++ b/test/test_remove.sh
@@ -63,11 +63,11 @@ pushd my-first-checkout
 export FAKETIME='-28d'
 
 echo Add measurement on commit in the past
-create_commit 
+create_commit
 git perf add -m test-measure-one 10.0
 num_measurements=$(git perf report -o - | wc -l)
-# Exactly one measurement should be present
-[[ ${num_measurements} -eq 1 ]] || exit 1
+# Exactly one measurement should be present (plus header row = 2 lines)
+[[ ${num_measurements} -eq 2 ]] || exit 1
 
 # Only published measurements can be expired
 git perf push
@@ -77,8 +77,8 @@ git perf push
 echo "Remove measurements on commits older than 7 days"
 git perf remove --older-than 7d || bash -i
 num_measurements=$(git perf report -o - | wc -l)
-# Nothing should have been removed
-[[ ${num_measurements} -eq 1 ]] || exit 1
+# Nothing should have been removed (1 measurement + header = 2 lines)
+[[ ${num_measurements} -eq 2 ]] || exit 1
 
 # --- 14 days ago
 export FAKETIME='-14d'
@@ -87,8 +87,8 @@ echo "Add a commit with a newer measurement"
 create_commit
 git perf add -m test-measure-two 20.0
 num_measurements=$(git perf report -o - | wc -l)
-# Two measurements should be there
-[[ ${num_measurements} -eq 2 ]] || exit 1
+# Two measurements should be there (plus header = 3 lines)
+[[ ${num_measurements} -eq 3 ]] || exit 1
 
 # Only published measurements can be expired
 git perf push
@@ -103,8 +103,8 @@ git for-each-ref
 echo "Remove older than 7 days measurements"
 git perf remove --older-than 7d
 num_measurements=$(git perf report -o - | wc -l)
-# One measurement should still be there
-[[ ${num_measurements} -eq 1 ]] || exit 1
+# One measurement should still be there (plus header = 2 lines)
+[[ ${num_measurements} -eq 2 ]] || exit 1
 # The measurement should be 20.0
 git perf report -o - | grep '20\.0'
 
@@ -174,8 +174,8 @@ git push
 git perf push
 
 num_measurements=$(git perf report -o - | wc -l)
-# One measurement should be there
-[[ ${num_measurements} -eq 1 ]] || exit 1
+# One measurement should be there (plus header = 2 lines)
+[[ ${num_measurements} -eq 2 ]] || exit 1
 
 # Verify that temporary write branches are cleaned up after push
 ref_count=$(git for-each-ref '**/notes/perf-*' | wc -l)

--- a/test/test_report_csv_aggregate.sh
+++ b/test/test_report_csv_aggregate.sh
@@ -25,16 +25,16 @@ git perf add -m timer 4.0
 agg_output=$(git perf report -m timer -a mean -o - | grep -v '^[[:space:]]*$')
 num_lines=$(echo "$agg_output" | grep -v '^[[:space:]]*$' | wc -l)
 
-if [[ "$num_lines" -ne 2 ]]; then
-  echo "Expected 2 summarized lines (one per commit), got: $num_lines"
+if [[ "$num_lines" -ne 3 ]]; then
+  echo "Expected 3 lines (1 header + 2 summarized), got: $num_lines"
   echo "Output: $agg_output"
   exit 1
 fi
 
-# Basic sanity: ensure measurement name appears on each line
+# Basic sanity: ensure measurement name appears on each data line + header
 name_count=$(echo "$agg_output" | grep -c "timer")
 if [[ "$name_count" -ne 2 ]]; then
-  echo "Expected measurement name 'timer' to appear on 2 lines, got: $name_count"
+  echo "Expected measurement name 'timer' to appear on 2 data lines, got: $name_count"
   exit 1
 fi
 

--- a/test/test_report_output_validation.sh
+++ b/test/test_report_output_validation.sh
@@ -28,10 +28,10 @@ git perf add -m timer 6.0 -k os=mac
 echo "=== Test 1: CSV output contains correct measurement values ==="
 csv_output=$(git perf report -m timer -o - | grep -v '^[[:space:]]*$')
 
-# Verify we have data lines (should be 6 measurements)
+# Verify we have header + data lines (should be 1 header + 6 measurements = 7 lines)
 line_count=$(echo "$csv_output" | grep -v '^[[:space:]]*$' | wc -l)
-if [[ "$line_count" -ne 6 ]]; then
-  echo "Expected 6 measurement lines in CSV, got: $line_count"
+if [[ "$line_count" -ne 7 ]]; then
+  echo "Expected 7 lines in CSV (1 header + 6 measurements), got: $line_count"
   echo "Output: $csv_output"
   exit 1
 fi
@@ -62,8 +62,8 @@ echo "=== Test 2: CSV aggregation produces correct calculated values ==="
 agg_output=$(git perf report -m timer -a mean -o - | grep -v '^[[:space:]]*$')
 
 line_count=$(echo "$agg_output" | grep -v '^[[:space:]]*$' | wc -l)
-if [[ "$line_count" -ne 3 ]]; then
-  echo "Expected 3 aggregated lines (one per commit), got: $line_count"
+if [[ "$line_count" -ne 4 ]]; then
+  echo "Expected 4 lines (1 header + 3 aggregated), got: $line_count"
   echo "Output: $agg_output"
   exit 1
 fi
@@ -80,10 +80,10 @@ echo "=== Test 3: CSV output with key-value filtering ==="
 # Filter to only ubuntu measurements
 ubuntu_output=$(git perf report -m timer -k os=ubuntu -o - | grep -v '^[[:space:]]*$')
 
-# Should have 4 ubuntu measurements (2 per commit for first 2 commits)
+# Should have 1 header + 4 ubuntu measurements (2 per commit for first 2 commits) = 5 lines
 line_count=$(echo "$ubuntu_output" | grep -v '^[[:space:]]*$' | wc -l)
-if [[ "$line_count" -ne 4 ]]; then
-  echo "Expected 4 ubuntu measurements, got: $line_count"
+if [[ "$line_count" -ne 5 ]]; then
+  echo "Expected 5 lines (1 header + 4 measurements), got: $line_count"
   echo "Output: $ubuntu_output"
   exit 1
 fi

--- a/test/testslow_concurrency_push_add.sh
+++ b/test/testslow_concurrency_push_add.sh
@@ -244,8 +244,8 @@ fi
 # Verify the results
 echo "Verifying results..."
 LINE_COUNT=$(git-perf report -o - | wc -l)
-# First seed measurement + measurements from adders
-EXPECTED_COUNT=$((NUM_ADD_ITERATIONS * CONCURRENT_ADDERS + 1))
+# First seed measurement + measurements from adders + header line
+EXPECTED_COUNT=$((NUM_ADD_ITERATIONS * CONCURRENT_ADDERS + 1 + 1))
 
 if [[ $LINE_COUNT -eq $EXPECTED_COUNT ]]; then
     echo "SUCCESS: Verification passed. Found exactly $EXPECTED_COUNT lines in the report."


### PR DESCRIPTION
## Summary

Implements Phase 4 of the measurement units support plan by adding a header row to CSV exports with a dedicated unit column. This enhancement makes CSV output more structured and self-documenting, with units retrieved from configuration and efficiently serialized using simple string formatting.

### Changes

#### CSV Export Implementation (Phase 4)
- ✅ Added CSV header row: `commit`, `epoch`, `measurement`, `timestamp`, `value`, `unit`
- ✅ Added dedicated `unit` column populated from configuration
- ✅ Implemented `CsvMeasurementRow` struct for type-safe representation
- ✅ Used efficient tab-delimited string formatting (no external dependencies)
- ✅ Float values formatted to always include decimal point (e.g., `3.0` not `3`)
- ✅ Metadata fields appended dynamically as additional columns

#### Test Updates
- Updated shell tests to account for CSV header row
- Fixed line count expectations in validation tests
- Fixed field extraction to skip header when needed
- All fast CSV-related tests passing

#### Documentation Updates
- Updated `measurement-units-support.md` plan to reflect Phase 4 completion
- Marked Phases 1-4 as complete with PR references
- Clarified CSV long format structure vs wide format

### Implementation Details

**CSV Output Format:**
```csv
commit	epoch	measurement	timestamp	value	unit	metadata...
abc123	0	build_time	1234567890.5	42.0	ms	os=linux
abc123	0	memory_usage	1234567890.6	1048576.0	bytes	os=linux
```

**Technical Approach:**
- Simple tab-delimited string building for CSV serialization
- `CsvMeasurementRow` struct with `unit` field for each measurement
- Units populated via `config::measurement_unit()` (empty string if not configured)
- Metadata fields appended dynamically per row
- Float formatting ensures decimals preserved (whole numbers show as `X.0`)
- No external dependencies added - uses standard string formatting

**Why Long Format:**
The CSV uses long format where each row is a measurement, not wide format where measurements are columns. This means:
- Each measurement appears as a data row
- Units displayed per-measurement in dedicated column
- Header describes field structure, not measurement names
- Consistent with existing reporter architecture

### Tests

All fast CSV-related tests passing:
- ✅ `test_report_output_validation.sh` - CSV values and headers
- ✅ `test_report_csv_aggregate.sh` - Aggregation with headers
- ✅ `test_measure.sh` - Measurement recording and retrieval
- ✅ `test_conflict_init.sh` - Multi-repo scenarios
- ✅ `test_pushpull_conflict.sh` - Merge conflict handling
- ✅ `test_broken_pipe.sh` - Pipe handling
- ✅ `test_operations_without_seed.sh` - Basic operations

Code quality checks:
- ✅ `cargo fmt` - All code properly formatted
- ✅ `cargo clippy` - No warnings
- ✅ `cargo build` - Clean compilation

### Phase Status Summary

1. ✅ Phase 1: Configuration Support (PR #419) - Complete
2. ✅ Phase 2: Audit Output Integration (PR #420, #422) - Complete
3. ✅ Phase 3: HTML Report Integration (PR #423) - Complete
4. ✅ Phase 4: CSV Export Integration (this PR) - Complete
5. ⚠️ Phase 5: Documentation - Partially complete
   - ✅ `example_config.toml` has unit examples
   - ❌ README needs unit configuration section
   - ❌ INTEGRATION_TUTORIAL needs unit usage examples

### Related

- Issue #330: feat(measurement): allow units in measurements
- Plan: `docs/plans/measurement-units-support.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)