### PR TITLE
feat(audit): show summaries on skip with sparkline

### DIFF
--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -233,8 +233,8 @@ fn audit_with_data(
     let build_summary = || -> String {
         let mut summary = String::new();
 
-        // Calculate total measurements: 1 head + N tail
-        let total_measurements = 1 + tail_summary.len;
+        // Use the length of all_measurements vector for total count
+        let total_measurements = all_measurements.len();
 
         // If only 1 total measurement (head only, no tail), show only head summary
         if total_measurements == 1 {


### PR DESCRIPTION
## Summary

When an audit is skipped due to insufficient measurements, the skip message now includes:
- The measurement name and sparkline visualization (already present)
- Z-score display (stddev/mad) calculated from head/tail when possible
- Head summary when at least one measurement exists
- Tail summary when two or more measurements exist

This enhancement provides richer context for skipped tests while maintaining the existing skip behavior.

## Changes

### Audit Logic (`git_perf/src/audit.rs`)

Modified the skip logic in `audit_with_data` to conditionally display summaries:
- **0 measurements**: Shows skip message and sparkline only
- **1 measurement**: Adds z-score line and Head summary
- **2+ measurements**: Adds z-score line and both Head and Tail summaries

The implementation builds the skip message progressively based on available measurements, using the existing `StatsWithUnit` formatting for consistency with normal audit output.

### Tests

Added `test_skip_with_summaries` to verify correct behavior across all measurement count scenarios:
- Verifies no summaries shown for 0 measurements
- Verifies z-score line and Head-only display for 1 measurement
- Verifies z-score line and both Head and Tail display for 2+ measurements

All existing tests continue to pass, including mutation testing coverage.

## Test Plan

- [x] Run `cargo test` - all tests pass including new test
- [x] Run `cargo fmt` - code properly formatted
- [x] Run `cargo clippy` - no warnings or errors
- [x] Verified skip messages include appropriate summaries based on measurement count
- [x] Confirmed backward compatibility with existing skip behavior

## Related

This builds on the existing sparkline enhancement to provide even more visibility into measurement data when audits are skipped.

🌿 Generated with [Terry](https://www.terragonlabs.com)

📎 **Task**: https://www.terragonlabs.com/task/9562e813-b029-48c7-94b4-ffcb4636414f