### PR TITLE
style(audit): remove #[allow(clippy::too_many_arguments)] attribute

### DIFF
--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -121,7 +121,6 @@ fn discover_matching_measurements(
     result
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn audit_multiple(
     max_count: usize,
     min_count: Option<u16>,


### PR DESCRIPTION
## Summary
- Removes redundant Clippy attribute #[allow(clippy::too_many_arguments)] from audit_multiple in git_perf/src/audit.rs
- No functional changes; lint suppression is removed to rely on standard Clippy checks

## Changes

### Code Cleanup
- Deleted #[allow(clippy::too_many_arguments)] that applied to audit_multiple
- No runtime behavior changes

## Rationale
- The suppression was redundant; removing it ensures Clippy warnings surface if the function grows beyond the recommended argument count in the future, and keeps the codebase consistent with lint expectations.

## Testing
- [x] Run cargo clippy to verify lint warnings are clean
- [x] Run cargo test to ensure no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/107b2148-7e08-4430-94b6-ea250c17c643