### PR TITLE
fix(ci): restore original branch on exit in cleanup script

### DIFF
--- a/scripts/cleanup-reports.sh
+++ b/scripts/cleanup-reports.sh
@@ -108,11 +108,19 @@ fi
 
 git checkout gh-pages
 
+# Set up trap to return to original branch on any exit
+cleanup() {
+    if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "gh-pages" ]; then
+        git checkout "$CURRENT_BRANCH" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
 echo "Deleting orphaned reports..."
 DELETED_COUNT=0
 for commit in $ORPHANED_REPORTS; do
     if git rm "${commit}.html" 2>/dev/null; then
-        ((DELETED_COUNT++))
+        ((DELETED_COUNT++)) || true  # Prevent errexit on arithmetic
     else
         echo "Warning: Could not remove ${commit}.html"
     fi
@@ -143,7 +151,4 @@ else
     echo "No changes to commit"
 fi
 
-# Return to original branch
-if [ -n "$CURRENT_BRANCH" ]; then
-    git checkout "$CURRENT_BRANCH"
-fi
+# The trap cleanup will automatically return to the original branch on exit


### PR DESCRIPTION
<pr-body>
## Summary
- Fix bash arithmetic expansion causing errexit when incrementing from 0
- Add EXIT trap to ensure repository returns to original branch on any exit
- Resolves "Can't find action.yml" errors in cleanup workflow

## Problem
The cleanup-measurements-and-reports.yml workflow has been failing since October 12th, 2025. The root cause is the `cleanup-reports.sh` script leaving the repository checked out on the `gh-pages` branch when it fails. This causes GitHub Actions to fail finding the composite action definition.

**Specific issue**: `((DELETED_COUNT++))` returns non-zero exit code when incrementing from 0, triggering bash `errexit` and leaving the repo on gh-pages.

## Test plan
- [x] Verify script syntax with `bash -n scripts/cleanup-reports.sh`
- [x] Confirm arithmetic fix prevents errexit: `bash -e -c '((x++)) || true'`
- [ ] PR will trigger dry-run cleanup workflow to verify fix works
- [x] Confirm trap returns to the original branch on exit
</pr-body>

📎 **Task**: https://www.terragonlabs.com/task/783ecb97-1b91-4de3-ae6d-24a94bc34a80