### PR TITLE
fix(ci): enforce lowercase first word after colon in PR titles

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -36,9 +36,9 @@ jobs:
             // - Must start with valid type
             // - Optional scope in parentheses (alphanumeric, hyphens, underscores)
             // - Colon and space required
-            // - Description must start with lowercase letter
+            // - First word of description must be lowercase (subsequent words can have uppercase for abbreviations)
             // Note: Scope validation is disabled - any scope is accepted
-            const conventionalCommitRegex = /^(feat|fix|docs|refactor|chore|test|perf|build|ci|revert)(\([a-z0-9_-]+\))?: [a-z].+$/;
+            const conventionalCommitRegex = /^(feat|fix|docs|refactor|chore|test|perf|build|ci|revert)(\([a-z0-9_-]+\))?: [a-z][a-z0-9]*(?:[ ].+)?$/;
 
             if (!conventionalCommitRegex.test(prTitle)) {
               let errorMessage = `❌ PR title does not follow Conventional Commits format.\n\n`;
@@ -53,7 +53,7 @@ jobs:
               errorMessage += `✅ \`chore(deps): update clap to 4.5.0\`\n\n`;
               errorMessage += `**Common mistakes:**\n`;
               errorMessage += `❌ Missing type prefix\n`;
-              errorMessage += `❌ Capital letter after colon (must be lowercase)\n`;
+              errorMessage += `❌ First word after colon starts with capital letter (must be lowercase)\n`;
               errorMessage += `❌ Missing colon\n`;
               errorMessage += `❌ Invalid type\n\n`;
               errorMessage += `See CLAUDE.md for more details.`;


### PR DESCRIPTION
## Summary
- Enforces that the first word after the colon in PR titles (Conventional Commits format) must start with lowercase.
- Subsequent words may include uppercase letters for abbreviations or proper nouns.
- Error messaging updated to reflect the new rule.

## Changes
### CI / Workflow
- .github/workflows/pr-title-check.yml: updated the conventional commits regex to require the first word after the colon to start with a lowercase letter and to allow optional additional words after that first word.
- Updated the helper error message to indicate the new rule: "First word after colon starts with capital letter (must be lowercase)".

### Documentation / Comments
- Updated inline comments to reflect the new policy:
  - "First word of description must be lowercase (subsequent words can have uppercase for abbreviations)".

## Test plan
- [x] Validate conforming PR titles like:
  - feat(ui): add new button
  - fix(auth): implement retry logic for token refresh
- [x] Validate non-conforming PR titles like:
  - feat(ui): Add new button
  - fix(auth): Authenticate user on page load (uppercase first word after colon)
- [x] Validate multi-word descriptions after the first word (subsequent words may contain uppercase):
  - feat(core): add Button Performance improvements

## Notes
- Scope validation remains disabled; any scope (alphanumeric, hyphens, underscores) is still accepted.
- This change tightens the casing rule to ensure consistent, readable PR titles.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c7eaa023-35c7-42fd-986c-9e7b0c6830e6