### PR TITLE
fix(ci): restore fatal audit behavior for core metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,9 @@ jobs:
           git perf add -m report-size -k os=${{matrix.os}} -k rust=${{matrix.rust}} $(wc -c < report.html)
           git perf push
 
-          git perf audit -n 40 -m test-measure2 -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 10 || echo "test-measure2 audit failed (expected on first runs or due to CI variability)"
-          git perf audit -n 40 -m report -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 10 || echo "report audit failed (expected on first runs or due to CI variability)"
-          git perf audit -n 40 -m report-size -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 10 || echo "report-size audit failed (expected on first runs or due to CI variability)"
+          git perf audit -n 40 -m test-measure2 -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 10
+          git perf audit -n 40 -m report -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 10
+          git perf audit -n 40 -m report-size -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 10
 
     - name: Archive report
       uses: actions/upload-artifact@v5


### PR DESCRIPTION
## Summary

Restores fatal audit behavior for test-measure2, report, and report-size measurements. These audits were accidentally made non-fatal in PR #460 (commit 2a9f2cc1fa4), which was intended to add PR title validation but also relaxed all audit commands.

## Problem

In PR #460, the following audits were changed from fatal to non-fatal:
- `test-measure2` - Core CI metric for performance testing
- `report` - Report generation performance
- `report-size` - Report size tracking

These are stable CI metrics that should fail the build when they regress, unlike the fibonacci benchmarks which have high inherent variability.

## Changes

Removes `|| echo "... audit failed ..."` from three audit commands in `.github/workflows/ci.yml`:
- Line 116: test-measure2 audit (now fatal)
- Line 117: report audit (now fatal)  
- Line 118: report-size audit (now fatal)

The fibonacci benchmark audits remain non-fatal as originally intended, since they have higher CI variability.

## Impact

- Audit failures for these three metrics will now properly fail the CI build
- Prevents performance regressions from being merged unnoticed
- PR #486 would have been blocked if this had been in place (audit showed significant regressions but checks passed)

## Test Plan

- [x] Code changes reviewed
- [x] `cargo fmt` passed
- [x] `cargo clippy` passed
- [ ] CI will validate that audit failures properly fail the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)