### PR TITLE
feat(ci): add subdirectory support for GitHub Pages reports

### DIFF
--- a/.github/actions/cleanup/README.md
+++ b/.github/actions/cleanup/README.md
@@ -83,6 +83,8 @@ jobs:
 | `backup` | Create backup of measurements before removal | No | `true` |
 | `cleanup-reports` | Also cleanup orphaned reports on gh-pages branch | No | `true` |
 | `git-perf-version` | Version of git-perf to use (latest or specific version) | No | `latest` |
+| `dry-run` | Perform dry-run without making actual changes | No | `false` |
+| `reports-subdirectory` | Subdirectory within gh-pages containing reports (must match report action) | No | `` |
 
 ## Permissions Required
 
@@ -189,8 +191,36 @@ If report cleanup fails:
 - Ensure the workflow has `pages: write` permission
 - Check that the gh-pages branch exists
 
+## Subdirectory Support
+
+If you're using the report action with `reports-subdirectory`, ensure the cleanup action uses the same subdirectory:
+
+```yaml
+- name: Cleanup measurements and reports
+  uses: kaihowl/git-perf/.github/actions/cleanup@master
+  with:
+    retention-days: 90
+    cleanup-reports: true
+    reports-subdirectory: 'perf'  # Must match report action
+```
+
+This ensures the cleanup script only removes orphaned reports from the specified subdirectory, leaving other content on gh-pages untouched.
+
+### Dry Run Example
+
+Test the cleanup before running it:
+
+```yaml
+- name: Test cleanup (dry-run)
+  uses: kaihowl/git-perf/.github/actions/cleanup@master
+  with:
+    dry-run: true
+    reports-subdirectory: 'perf'
+```
+
 ## See Also
 
 - [git-perf Install Action](../install/README.md)
+- [git-perf Report Action](../report/README.md)
 - [git-perf Documentation](https://github.com/kaihowl/git-perf)
 - [Integration Tutorial](../../../docs/INTEGRATION_TUTORIAL.md) *(coming soon)*

--- a/.github/actions/cleanup/action.yml
+++ b/.github/actions/cleanup/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Perform dry-run without making actual changes'
     required: false
     default: 'false'
+  reports-subdirectory:
+    description: 'Subdirectory within gh-pages containing reports (must match report action)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -82,15 +86,24 @@ runs:
     - name: Cleanup orphaned reports
       if: inputs.cleanup-reports == 'true'
       shell: bash
+      env:
+        REPORTS_SUBDIR: ${{ inputs.reports-subdirectory }}
       run: |
         # Run cleanup script to remove reports without measurements
         # Use -y flag for non-interactive execution in CI
+        # Pass subdirectory via environment variable
         if [ -f ./scripts/cleanup-reports.sh ]; then
           chmod +x ./scripts/cleanup-reports.sh
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "[DRY-RUN] Would cleanup orphaned reports"
+            if [ -n "$REPORTS_SUBDIR" ]; then
+              echo "  in subdirectory: $REPORTS_SUBDIR"
+            fi
             ./scripts/cleanup-reports.sh --dry-run || echo "Cleanup script failed but continuing"
           else
+            if [ -n "$REPORTS_SUBDIR" ]; then
+              echo "Cleaning up reports in subdirectory: $REPORTS_SUBDIR"
+            fi
             ./scripts/cleanup-reports.sh -y || echo "Cleanup script failed but continuing"
           fi
         else

--- a/.github/actions/report/README.md
+++ b/.github/actions/report/README.md
@@ -7,6 +7,7 @@ A GitHub Action to generate and publish git-perf performance reports to GitHub P
 - Generates HTML performance reports using `git-perf report`
 - Optionally runs `git-perf audit` for performance analysis
 - Publishes reports to GitHub Pages
+- **Supports subdirectory organization** for coexistence with existing documentation
 - Automatically comments on pull requests with report URL and audit results
 - Supports custom report naming and depth configuration
 - Returns report URL and audit output for use in subsequent steps
@@ -77,6 +78,10 @@ The action automatically comments on PRs by default. To disable automatic commen
 | `audit-args` | Additional arguments to git-perf audit (e.g., `-m <measurement> -d <threshold>`) | No | `` |
 | `git-perf-version` | Version of git-perf to use (latest, or specific version) | No | `latest` |
 | `comment-on-pr` | Whether to comment on the PR with the report URL (only for pull_request events) | No | `true` |
+| `show-size` | Whether to show measurement storage size in output | No | `false` |
+| `size-use-disk-size` | Whether to use disk-size (compressed) instead of logical size | No | `true` |
+| `reports-subdirectory` | Subdirectory within gh-pages for reports (e.g., "perf", "reports"). Empty for root. | No | `` |
+| `preserve-existing` | Preserve existing gh-pages content outside reports subdirectory | No | `true` |
 | `github-token` | GitHub token for publishing to gh-pages and commenting on PRs | Yes | - |
 
 ### Common Audit Arguments
@@ -177,11 +182,118 @@ jobs:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+## Subdirectory Organization
+
+The action supports deploying reports to a subdirectory within GitHub Pages, allowing coexistence with existing documentation sites.
+
+### Deploy to Subdirectory
+
+```yaml
+- uses: kaihowl/git-perf/.github/actions/report@master
+  with:
+    reports-subdirectory: 'perf'
+    preserve-existing: 'true'
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+This deploys reports to `https://user.github.io/repo/perf/` instead of the root.
+
+### Multi-Workflow Coordination
+
+When combining performance reports with existing documentation (MkDocs, Jekyll, etc.), use proper concurrency control:
+
+```yaml
+name: Performance Reports
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pages: write
+  pull-requests: write
+
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false  # Queue deployments, don't cancel
+
+jobs:
+  report:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 100
+
+      - uses: kaihowl/git-perf/.github/actions/report@master
+        with:
+          reports-subdirectory: 'perf'
+          preserve-existing: 'true'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Documentation Workflow Example:**
+
+```yaml
+name: Deploy Documentation
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+
+permissions:
+  contents: write
+  pages: write
+
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false  # Same group as performance workflow
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+      - run: pip install mkdocs-material
+      - run: mkdocs build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          keep_files: true  # Preserve perf/ reports
+```
+
+### Subdirectory Best Practices
+
+1. **Use the same concurrency group** across all workflows deploying to gh-pages
+2. **Set `cancel-in-progress: false`** to queue deployments instead of canceling
+3. **Set `keep_files: true`** in all deployment actions to preserve existing content
+4. **Use descriptive subdirectory names**: `perf`, `reports`, `benchmarks`, etc.
+5. **Match subdirectory in cleanup action**: Ensure cleanup uses the same subdirectory
+
+### Repository Structure Result
+
+```
+gh-pages branch:
+├── index.html           # Documentation root (MkDocs/Jekyll)
+├── docs/               # Documentation pages
+│   └── ...
+└── perf/               # Performance reports
+    ├── main.html       # Branch reports
+    ├── develop.html
+    └── abc123....html  # Commit reports
+```
+
 ## Notes
 
 - **Concurrency Control**: The action does NOT enforce concurrency control internally. You MUST add concurrency control at the job/workflow level to prevent concurrent pushes to the gh-pages branch, which could cause conflicts.
 - **Automatic PR Comments**: By default, the action automatically comments on pull requests with the report URL and audit results. Set `comment-on-pr: 'false'` to disable.
 - **PR Comment Updates**: If a performance comment already exists, the action updates it instead of creating a new one.
 - **GitHub Pages**: The action uses `peaceiris/actions-gh-pages@v4` to publish to GitHub Pages with `keep_files: true`, preserving previous reports.
+- **Subdirectory Security**: The action validates subdirectory paths to prevent path traversal attacks (rejects `..`, absolute paths, and special characters).
 - **Error Handling**: If `git perf pull` fails, the action continues with a warning (useful for missing git objects).
 - **Audit Failures**: Audit results are captured even if the audit command fails, ensuring workflow continues.

--- a/.github/actions/report/action.yml
+++ b/.github/actions/report/action.yml
@@ -42,11 +42,19 @@ inputs:
     description: 'Whether to use disk-size (compressed) instead of logical size'
     required: false
     default: 'true'
+  reports-subdirectory:
+    description: 'Subdirectory within gh-pages for reports (e.g., "perf", "reports"). Empty for root.'
+    required: false
+    default: ''
+  preserve-existing:
+    description: 'Preserve existing gh-pages content outside reports subdirectory'
+    required: false
+    default: 'true'
 
 outputs:
   report-url:
     description: 'URL of the published report'
-    value: ${{ steps.get-pages-url.outputs.pages-url }}/${{ steps.set-report-name.outputs.report-name }}.html
+    value: ${{ steps.get-pages-url.outputs.full-report-url }}
   audit-output:
     description: 'Output from git-perf audit command'
     value: ${{ steps.audit.outputs.audit-output }}
@@ -57,6 +65,25 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate subdirectory input
+      shell: bash
+      run: |
+        SUBDIR="${{ inputs.reports-subdirectory }}"
+        if [ -n "$SUBDIR" ]; then
+          # Security: Reject paths containing .., absolute paths, or invalid characters
+          if [[ "$SUBDIR" =~ \.\. ]] || [[ "$SUBDIR" == /* ]] || [[ ! "$SUBDIR" =~ ^[a-zA-Z0-9_/-]+$ ]]; then
+            echo "Error: Invalid subdirectory path '$SUBDIR'"
+            echo "Subdirectory must:"
+            echo "  - Not contain '..' (parent directory references)"
+            echo "  - Not be an absolute path (starting with /)"
+            echo "  - Only contain alphanumeric characters, underscores, hyphens, and forward slashes"
+            exit 1
+          fi
+          echo "✓ Subdirectory validation passed: $SUBDIR"
+        else
+          echo "✓ Using root directory (no subdirectory specified)"
+        fi
+
     - name: Install git-perf
       uses: kaihowl/git-perf/.github/actions/install@master
       with:
@@ -137,7 +164,8 @@ runs:
       with:
         github_token: ${{ inputs.github-token }}
         publish_dir: ./reports
-        keep_files: true
+        destination_dir: ${{ inputs.reports-subdirectory }}
+        keep_files: ${{ inputs.preserve-existing == 'true' }}
 
     - name: Get Pages URL
       id: get-pages-url
@@ -149,15 +177,26 @@ runs:
         echo "pages-url=$pages_url" >> $GITHUB_OUTPUT
         echo "Pages URL: $pages_url"
 
+        # Construct full report URL including subdirectory
+        SUBDIR="${{ inputs.reports-subdirectory }}"
+        REPORT_NAME="${{ steps.set-report-name.outputs.report-name }}"
+        if [ -n "$SUBDIR" ]; then
+          # Remove trailing slash from pages_url if present
+          pages_url="${pages_url%/}"
+          full_report_url="${pages_url}/${SUBDIR}/${REPORT_NAME}.html"
+        else
+          full_report_url="${pages_url}/${REPORT_NAME}.html"
+        fi
+        echo "full-report-url=$full_report_url" >> $GITHUB_OUTPUT
+        echo "Full report URL: $full_report_url"
+
     - name: Comment on PR
       if: ${{ github.event_name == 'pull_request' && inputs.comment-on-pr == 'true' }}
       uses: actions/github-script@v8
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const reportName = '${{ steps.set-report-name.outputs.report-name }}'
-          const pagesUrl = '${{ steps.get-pages-url.outputs.pages-url }}'
-          const reportUrl = `${pagesUrl}/${reportName}.html`
+          const reportUrl = '${{ steps.get-pages-url.outputs.full-report-url }}'
 
           const auditOutput = `${{ steps.audit.outputs.audit-output }}`.trim()
           const auditSection = auditOutput ? `\n\n## Audit Results\n\n\`\`\`\n${auditOutput}\n\`\`\`` : ''


### PR DESCRIPTION
## Summary

Implements **Phase 1: Subdirectory Organization** from the [GitHub Pages Integration and Templating Plan](../blob/master/docs/plans/github-pages-integration-and-templating.md) to enable git-perf reports to coexist with existing documentation sites on GitHub Pages.

## Changes

### Report Action (`.github/actions/report/action.yml`)
- ✅ Add `reports-subdirectory` input parameter (e.g., "perf", "reports")
- ✅ Add `preserve-existing` input parameter (default: true)
- ✅ Implement subdirectory deployment using `destination_dir` for peaceiris action
- ✅ Add path validation to prevent traversal attacks
- ✅ Update report URL generation to include subdirectory path
- ✅ Add comprehensive documentation with multi-workflow examples

### Cleanup Action (`.github/actions/cleanup/action.yml`)
- ✅ Add `reports-subdirectory` input parameter
- ✅ Pass subdirectory to cleanup script via `REPORTS_SUBDIR` environment variable
- ✅ Update documentation with subdirectory usage examples

### Cleanup Script (`scripts/cleanup-reports.sh`)
- ✅ Respect `REPORTS_SUBDIR` environment variable
- ✅ List reports only from specified subdirectory
- ✅ Delete reports with subdirectory-aware paths
- ✅ Maintain backward compatibility (empty subdirectory = root)

### Documentation
- ✅ Multi-workflow coordination examples (MkDocs + perf reports, Jekyll + perf reports)
- ✅ Concurrency control best practices (`gh-pages-deploy` group)
- ✅ Security considerations (path validation)
- ✅ Repository structure diagrams

## Use Cases Enabled

**Example 1: MkDocs Documentation + Performance Reports**
```yaml
# docs.yml - deploys to root
- uses: peaceiris/actions-gh-pages@v4
  with:
    publish_dir: ./site
    keep_files: true  # Preserve perf/

# perf.yml - deploys to /perf/
- uses: kaihowl/git-perf/.github/actions/report@master
  with:
    reports-subdirectory: 'perf'
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

**Result:**
- Docs: `https://user.github.io/repo/`
- Reports: `https://user.github.io/repo/perf/`

## Testing

- ✅ Bash script syntax validated (`bash -n`)
- ✅ YAML structure validated
- ✅ Path validation logic prevents `..`, absolute paths, special characters
- ✅ Backward compatibility maintained (empty subdirectory = root deployment)
- ⏳ Manual workflow testing (to be performed post-merge in a test repository)

## Security

- Path validation rejects:
  - Parent directory references (`..`)
  - Absolute paths (`/foo`)
  - Special characters (only `[a-zA-Z0-9_/-]` allowed)
- Cleanup script only operates within specified subdirectory
- No changes to file permissions or execution

## Backward Compatibility

✅ **Fully backward compatible**
- Default `reports-subdirectory` is empty string (root deployment)
- Default `preserve-existing` is true (same as current `keep_files: true`)
- Existing workflows continue working without changes

## Related Work

- Plan: [docs/plans/github-pages-integration-and-templating.md](../blob/master/docs/plans/github-pages-integration-and-templating.md)
- Phase 1 (this PR): Subdirectory Organization ✅
- Phase 2 (future): Report Templating
- Phase 2b (future): Multi-Configuration Templates
- Phase 3 (future): Index Generation

## Checklist

- [x] Code follows project conventions
- [x] Bash syntax validated
- [x] Documentation updated (README files)
- [x] Security considerations addressed
- [x] Backward compatibility maintained
- [x] Commit message follows Conventional Commits format

🤖 Generated with [Claude Code](https://claude.com/claude-code)