### PR TITLE
test(ci): verify CI pipeline with no-op change

### DIFF
--- a/git_perf/src/main.rs
+++ b/git_perf/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use git_perf::cli;
 
+// Main entry point
 fn main() -> Result<()> {
     cli::handle_calls()
 }


### PR DESCRIPTION
## Summary
- Added a simple comment to `git_perf/src/main.rs` to test CI pipeline
- No functional changes - purely for CI verification

## Test plan
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings
- [x] Compiles successfully
- [ ] CI passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)