### PR TITLE
fix(ci): switch back to original branch after gh-pages push in cleanup action

### DIFF
--- a/.github/actions/cleanup/action.yml
+++ b/.github/actions/cleanup/action.yml
@@ -116,6 +116,10 @@ runs:
       shell: bash
       run: |
         if git rev-parse --verify gh-pages >/dev/null 2>&1; then
+          # Save current branch and set up trap to restore it on exit
+          ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          trap "git checkout '$ORIGINAL_BRANCH'" EXIT
+
           git checkout gh-pages
           if [ -n "$(git status --porcelain)" ]; then
             git push origin gh-pages


### PR DESCRIPTION
## Summary
- Ensures the cleanup action restores the original branch after pushing to gh-pages by saving the current branch and restoring on exit.

## Problem
- The cleanup action switched to the `gh-pages` branch to push changes but did not reliably revert to the original branch, which could leave the working directory on `gh-pages` when the composite action completes and subsequently fails.

Error message (relevant context):
```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under 
'/home/runner/work/git-perf/git-perf/.github/actions/cleanup'. 
Did you forget to run actions/checkout before running your local action?
```

## Solution
- Save the original branch name before `git checkout gh-pages`
- Restore the original branch on EXIT (via trap), so the working directory is back to the original branch when the composite action completes

## Test plan
- [ ] Review the code changes
- [ ] Verify the cleanup workflow runs successfully on this PR
- [ ] Check that gh-pages changes are still pushed correctly

## Related
Fixes issue from https://github.com/kaihowl/git-perf/actions/runs/19792687161/job/56708088711


📎 **Task**: https://www.terragonlabs.com/task/60992786-96cb-4eb0-98ca-36ec662c79ab