### PR TITLE
test(mutation): include measurement_retrieval in mutation testing

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,5 +1,5 @@
 test_tool = "nextest"
-exclude_globs = ["examples/**", "benches/**", "git_perf/tests/**", "git_perf/src/main.rs", "git_perf/src/cli.rs", "git_perf/src/measurement_retrieval.rs"]
+exclude_globs = ["examples/**", "benches/**", "git_perf/tests/**", "git_perf/src/main.rs", "git_perf/src/cli.rs"]
 additional_cargo_test_args = ["--", "--skip", "slow"]
 timeout_multiplier = 2.0
 minimum_test_timeout = 60


### PR DESCRIPTION
## Summary
- Removes measurement_retrieval.rs from the exclude_globs in `.cargo/mutants.toml` to enable mutation testing for this module.

## Changes
- `.cargo/mutants.toml`: Deleted `git_perf/src/measurement_retrieval.rs` from the `exclude_globs` list. This file will now be included in mutation runs.

## Rationale
- Ensures the measurement retrieval logic is covered by mutation testing and reduces blind spots in test coverage.

## Test plan
- [x] Run mutation testing locally to verify `measurement_retrieval.rs` is now mutated
- [x] Ensure the full test suite passes with the updated config
- [x] Check CI runs to confirm no regressions or unintended exclusions were introduced

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/97a5df75-4143-4857-9bd0-836ecde2567a