### PR TITLE
Remove magic numbers by introducing defaults; delete review file

### DIFF
--- a/git_perf/src/defaults.rs
+++ b/git_perf/src/defaults.rs
@@ -68,6 +68,22 @@ pub const DEFAULT_EPOCH: u32 = 0;
 // See git/git_definitions.rs:28 for the implementation.
 
 // ============================================================================
+// Reporting Configuration Defaults
+// ============================================================================
+
+/// Default number of characters to display from commit SHA in report metadata.
+///
+/// This value is used when displaying commit ranges in report headers,
+/// providing a balance between readability and uniqueness.
+pub const DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA: usize = 7;
+
+/// Default number of characters to display from commit SHA in report x-axis.
+///
+/// This value is used when displaying commit hashes on the x-axis of plots,
+/// optimized for display space and readability in interactive visualizations.
+pub const DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_AXIS: usize = 6;
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 
@@ -93,6 +109,18 @@ pub const fn default_backoff_max_elapsed_seconds() -> u64 {
 #[inline]
 pub const fn default_epoch() -> u32 {
     DEFAULT_EPOCH
+}
+
+/// Returns the default commit hash display length for metadata.
+#[inline]
+pub const fn default_commit_hash_display_length_metadata() -> usize {
+    DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA
+}
+
+/// Returns the default commit hash display length for axis.
+#[inline]
+pub const fn default_commit_hash_display_length_axis() -> usize {
+    DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_AXIS
 }
 
 #[cfg(test)]
@@ -121,5 +149,17 @@ mod tests {
     fn test_default_epoch() {
         assert_eq!(DEFAULT_EPOCH, 0);
         assert_eq!(default_epoch(), 0);
+    }
+
+    #[test]
+    fn test_default_commit_hash_display_length_metadata() {
+        assert_eq!(DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA, 7);
+        assert_eq!(default_commit_hash_display_length_metadata(), 7);
+    }
+
+    #[test]
+    fn test_default_commit_hash_display_length_axis() {
+        assert_eq!(DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_AXIS, 6);
+        assert_eq!(default_commit_hash_display_length_axis(), 6);
     }
 }

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -18,6 +18,9 @@ use plotly::{
 use crate::{
     config,
     data::{Commit, MeasurementData, MeasurementSummary},
+    defaults::{
+        DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_AXIS, DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA,
+    },
     measurement_retrieval::{self, MeasurementReducer},
     stats::ReductionFunc,
 };
@@ -49,12 +52,12 @@ impl ReportMetadata {
         let commit_range = if commits.is_empty() {
             "No commits".to_string()
         } else if commits.len() == 1 {
-            commits[0].commit[..7].to_string()
+            commits[0].commit[..DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA].to_string()
         } else {
             format!(
                 "{}..{}",
-                &commits.last().unwrap().commit[..7],
-                &commits[0].commit[..7]
+                &commits.last().unwrap().commit[..DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA],
+                &commits[0].commit[..DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA]
             )
         };
 
@@ -345,7 +348,12 @@ impl<'a> Reporter<'a> for PlotlyReporter {
         self.size = commits.len();
 
         let (commit_nrs, short_hashes): (Vec<_>, Vec<_>) = enumerated_commits
-            .map(|(n, c)| (n as f64, c.commit[..6].to_owned()))
+            .map(|(n, c)| {
+                (
+                    n as f64,
+                    c.commit[..DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_AXIS].to_owned(),
+                )
+            })
             .unzip();
         let x_axis = Axis::new()
             .tick_values(commit_nrs)


### PR DESCRIPTION
## Summary
- Replaces hard-coded hash display lengths with explicit defaults
- Introduces default constants and inline getters for commit hash display lengths
- Refactors reporting to consume new defaults for metadata and axis displays
- Adds tests to verify default values
- Deletes code review file as part of cleanup

## Changes

### Defaults
- Added constants in git_perf/src/defaults.rs:
  - DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA: usize = 7
  - DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_AXIS: usize = 6
- Added inline getters:
  - default_commit_hash_display_length_metadata() -> usize
  - default_commit_hash_display_length_axis() -> usize

### Reporting
- Updated git_perf/src/reporting.rs to use the new defaults:
  - For metadata commit range display, use DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA
  - For multi-commit range display, use DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA
  - For the x-axis plot, use DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_AXIS

### Tests
- Added tests to validate defaults in defaults.rs:
  - DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_METADATA == 7 and getter returns 7
  - DEFAULT_COMMIT_HASH_DISPLAY_LENGTH_AXIS == 6 and getter returns 6

### Cleanup
- Deleted CODE_REVIEW.md (or the relevant code review document) as part of cleanup

## Test plan
- Run cargo test to ensure all tests pass, including new defaults tests
- Verify that report metadata headers display 7-character hashes and axis labels show 6-character hashes
- Confirm no regressions in plots and metadata formatting


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6fd12da2-a2dd-4a72-9739-cb725cbd1a20