### PR TITLE
feat(reporting): warn when template argument is used with CSV output

### DIFF
--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -1565,6 +1565,13 @@ pub fn report(
 
     plot.add_commits(&commits);
 
+    // Warn if template is provided with CSV output
+    let is_csv =
+        output.extension().and_then(|s| s.to_str()) == Some("csv") || output == Path::new("-");
+    if is_csv && template_config.template_path.is_some() {
+        log::warn!("Template argument is ignored for CSV output format");
+    }
+
     // For HTML reports, always use the template-based approach (single or multi-section)
     if output.extension().and_then(|s| s.to_str()) == Some("html") {
         let template = load_template(template_config.template_path.as_ref())?;

--- a/test/test_report_csv_template_warning.sh
+++ b/test/test_report_csv_template_warning.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+set -x
+
+script_dir=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
+# shellcheck source=test/common.sh
+source "$script_dir/common.sh"
+
+# Verify that providing --template with CSV output shows a warning
+
+cd_empty_repo
+
+# Create a commit with measurements
+create_commit
+git perf add -m timer 1.0
+
+# Create a dummy template file
+template_file=$(mktemp)
+echo "<html><body>{{PLOTLY_BODY}}</body></html>" > "$template_file"
+
+# Test 1: CSV file with template should warn
+csv_output=$(mktemp --suffix=.csv)
+warn_output=$(git perf report -m timer -o "$csv_output" --template "$template_file" 2>&1 || true)
+assert_output_contains "$warn_output" "Template argument is ignored for CSV output format" "Expected warning about template being ignored for CSV output"
+
+# Test 2: Stdout (CSV) with template should warn
+stdout_output=$(git perf report -m timer -o - --template "$template_file" 2>&1 || true)
+assert_output_contains "$stdout_output" "Template argument is ignored for CSV output format" "Expected warning about template being ignored for stdout (CSV) output"
+
+# Test 3: HTML file with template should NOT warn (legitimate use case)
+html_output=$(mktemp --suffix=.html)
+html_warn_output=$(git perf report -m timer -o "$html_output" --template "$template_file" 2>&1 || true)
+assert_output_not_contains "$html_warn_output" "Template argument is ignored" "HTML output should NOT warn about template usage"
+
+# Clean up
+rm -f "$template_file" "$csv_output" "$html_output"
+
+echo "CSV template warning test passed."


### PR DESCRIPTION
## Summary
- Adds a runtime warning when a template is provided while generating CSV output, preventing silent template ignoring.
- Introduces automated tests to validate warning behavior for CSV and non-CSV (HTML) outputs.

## Changes

### Core Functionality
- git_perf/src/reporting.rs: Detect CSV output (extension "csv" or stdout "-") and, if a template path is provided, emit a warning:
  - Message: "Template argument is ignored for CSV output format".

### Tests
- Added test/test_report_csv_template_warning.sh
  - Verifies warning behavior across three scenarios:
    1. CSV file output with a template should warn.
    2. Stdout (CSV) with a template should warn.
    3. HTML output with a template should NOT warn.

## Test Plan
- Run the new shell test: test/test_report_csv_template_warning.sh
- Or execute the repository’s standard test suite as documented, ensuring:
  - The warning appears for CSV outputs when a template is provided.
  - The warning does not appear for HTML outputs.

## Notes
- This change is non-breaking and only adds a user-facing warning to improve clarity when a CSV output is used with templates.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6b31e98f-1099-414b-9e60-915f3a2c320f