### PR TITLE
docs: document storage model, epochs, and fix add command syntax

### DIFF
--- a/docs/INTEGRATION_TUTORIAL.md
+++ b/docs/INTEGRATION_TUTORIAL.md
@@ -59,7 +59,7 @@ cd /path/to/your/project
 
 # Add a measurement (e.g., build time in seconds)
 # You'll typically get this value from your build or test process
-git perf add -m build_time 42.5
+git perf add 42.5 -m build_time
 
 # Generate an HTML report (creates output.html by default)
 git perf report
@@ -177,7 +177,7 @@ jobs:
       - name: Measure binary size
         run: |
           binary_size=$(stat -c%s target/release/your-binary)
-          git perf add -m binary_size "$binary_size"
+          git perf add "$binary_size" -m binary_size
 
       # Push measurements back to the repository
       - name: Push measurements
@@ -260,7 +260,7 @@ jobs:
       - name: Measure binary size
         run: |
           binary_size=$(stat -c%s target/release/your-binary)
-          git perf add -m binary_size "$binary_size"
+          git perf add "$binary_size" -m binary_size
 
       - name: Push measurements
         run: git perf push
@@ -779,7 +779,7 @@ jobs:
           git perf measure -m build_time -- cargo build --release
 
           size=$(stat -c%s target/release/my-app)
-          git perf add -m binary_size "$size"
+          git perf add "$size" -m binary_size
 
       - name: Test and measure
         run: git perf measure -m test_duration -- cargo test --release


### PR DESCRIPTION
## Summary
- Adds comprehensive documentation on how git-perf stores measurements and how epochs affect audits. 
- Introduces the Epochs concept (and why they’re version-controlled) to the docs, with usage and configuration guidance. 
- Updates usage examples to reflect the canonical command syntax: `git perf add <value> -m <metric>` across README and the integration tutorial.

## Changes

### README.md
- Added a new section: **How git-perf Works: Storage and Workflow** that covers:
  - Git-Notes Storage Model: using `refs/notes/perf-v3` and line-delimited, field-separated measurements.
  - Merge Strategy: `cat_sort_uniq` for deduplicating concurrent measurements.
  - Pull Request Workflow: first-parent traversal behavior and how measurements attach to merge commits.
  - Why Git-Notes?: non-invasive, retroactive, independent sync, centralized collection.
  - Verifying Stored Measurements: commands to list and view measurements.

- Added a new section: **Epochs: Accepting Expected Performance Changes** that explains:
  - What epochs are and how they’re tied to commits (first 8 chars).
  - Why epochs are stored in `.gitperfconfig` (version-controlled) and the merge-conflict considerations.
  - How to use epochs, including updating and committing epoch changes, and adding new measurements with the new epoch.
  - Per-measurement and global epoch configuration examples.
  - Audit prerequisites and workflow when using epochs.

- Updated quick-start snippet and verification steps to use the new add syntax:
  - From: `git perf add build_time 42.5` to: `git perf add 42.5 -m build_time`
  - Added: `git notes --ref=refs/notes/perf-v3 list | head -1` for optional verification before auditing.

### docs/INTEGRATION_TUTORIAL.md
- Replaced instances of the old syntax with the new canonical syntax:
  - From: `git perf add -m build_time 42.5` to: `git perf add 42.5 -m build_time`.
  - All occurrences in CI/jobs examples where measurements are captured now reflect `git perf add [value] -m <metric>`.
- Updated multiple examples where binary_size or similar measurements are captured, ensuring consistency with the new syntax.

## Rationale
- Aligns documentation with the maintained command conventions and maintains consistency across docs.
- Introduces the epoch mechanism with clear guidance, improving audit reliability and team collaboration.
- Provides visibility into storage architecture (git-notes) to help maintainers understand data flow and historical data handling.

## Validation / Testing Plan
- [ ] Review README.md to ensure all new sections render correctly and anchors exist (e.g., Storage and Workflow, Epochs).
- [ ] Search for all instances of the old syntax `git perf add -m ...` and confirm replacements in README and docs.
- [ ] Build or preview docs locally if your workflow supports it to verify formatting and link integrity.
- [ ] Validate that the new example commands reflect expected usage and won’t break pipelines relying on the previous syntax (update documentation only).

## Notes
- The changes are documentation-focused and do not modify runtime behavior. They are intended to clarify architecture, usage, and audit semantics per maintainer feedback.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/33704b88-30fe-4a4e-8505-dc39e729f809