### PR TITLE
feat: rename detect-changes to show-changes

### DIFF
--- a/.github/actions/report/README.md
+++ b/.github/actions/report/README.md
@@ -86,7 +86,7 @@ The action automatically comments on PRs by default. To disable automatic commen
 | `reports-subdirectory` | Subdirectory within gh-pages for reports (e.g., "perf", "reports"). Empty for root. | No | `` |
 | `preserve-existing` | Preserve existing gh-pages content outside reports subdirectory | No | `true` |
 | `show-epochs` | Whether to show epoch boundaries in the report | No | `false` |
-| `detect-changes` | Whether to detect and display change points in the report | No | `false` |
+| `show-changes` | Whether to detect and display change points in the report | No | `false` |
 | `github-token` | GitHub token for publishing to gh-pages and commenting on PRs | Yes | - |
 
 ### Common Audit Arguments
@@ -240,7 +240,7 @@ This deploys reports to `https://user.github.io/repo/perf/` instead of the root.
 - uses: kaihowl/git-perf/.github/actions/report@master
   with:
     show-epochs: 'true'
-    detect-changes: 'true'
+    show-changes: 'true'
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/.github/actions/report/action.yml
+++ b/.github/actions/report/action.yml
@@ -54,7 +54,7 @@ inputs:
     description: 'Whether to show epoch boundaries in the report'
     required: false
     default: 'false'
-  detect-changes:
+  show-changes:
     description: 'Whether to detect and display change points in the report'
     required: false
     default: 'false'
@@ -131,8 +131,8 @@ runs:
         fi
 
         CHANGES_FLAG=""
-        if [ "${{ inputs.detect-changes }}" = "true" ]; then
-          CHANGES_FLAG="--detect-changes"
+        if [ "${{ inputs.show-changes }}" = "true" ]; then
+          CHANGES_FLAG="--show-changes"
         fi
 
         git perf report -n ${{ inputs.depth }} -o reports/${{ steps.set-report-name.outputs.report-name }}.html $EPOCH_FLAG $CHANGES_FLAG ${{ inputs.additional-args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
           show-size: 'true'
           size-use-disk-size: 'true'
           show-epochs: 'true'
-          detect-changes: 'true'
+          show-changes: 'true'
 
   release-binary-size:
     name: release-binary-size

--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -278,7 +278,7 @@ pub enum Commands {
 
         /// Detect and show change points in the report (hidden by default, toggleable via legend)
         #[arg(long)]
-        detect_changes: bool,
+        show_changes: bool,
     },
 
     /// For given measurements, check perfomance deviations of the HEAD commit

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -182,7 +182,7 @@ Create an HTML performance report
 * `-c`, `--custom-css <CUSTOM_CSS>` — Path to custom CSS file to inject into the template
 * `--title <TITLE>` — Custom title for the report (overrides default)
 * `--show-epochs` — Show epoch boundary markers in the report (hidden by default, toggleable via legend)
-* `--detect-changes` — Detect and show change points in the report (hidden by default, toggleable via legend)
+* `--show-changes` — Detect and show change points in the report (hidden by default, toggleable via legend)
 
 
 

--- a/docs/plans/change-point-detection.md
+++ b/docs/plans/change-point-detection.md
@@ -233,7 +233,7 @@ impl PlotlyReporter {
 
 ```bash
 # Report with visualizations
-git perf report output.html --show-epochs --detect-changes
+git perf report output.html --show-epochs --show-changes
 
 # Audit with change point warning
 git perf audit -m build_time  # warns if change point in epoch

--- a/git_perf/src/cli.rs
+++ b/git_perf/src/cli.rs
@@ -66,7 +66,7 @@ pub fn handle_calls() -> Result<()> {
             custom_css,
             title,
             show_epochs,
-            detect_changes,
+            show_changes,
         } => {
             // Combine measurements (as exact matches) and filter patterns into unified regex patterns
             let combined_patterns =
@@ -87,7 +87,7 @@ pub fn handle_calls() -> Result<()> {
                 &combined_patterns,
                 template_config,
                 show_epochs,
-                detect_changes,
+                show_changes,
             )
         }
         Commands::Audit {

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -937,7 +937,7 @@ pub fn report(
     combined_patterns: &[String],
     template_config: ReportTemplateConfig,
     show_epochs: bool,
-    detect_changes: bool,
+    show_changes: bool,
 ) -> Result<()> {
     // Compile combined regex patterns (measurements as exact matches + filter patterns)
     // early to fail fast on invalid patterns
@@ -1147,7 +1147,7 @@ pub fn report(
                 }
 
                 // Add change point traces if requested
-                if detect_changes {
+                if show_changes {
                     log::debug!("Running change point detection for {}", measurement_name);
                     let config = crate::config::change_point_config(measurement_name);
                     // Reverse measurements to match display order (newest on left, oldest on right)

--- a/man/man1/git-perf-report.1
+++ b/man/man1/git-perf-report.1
@@ -4,7 +4,7 @@
 .SH NAME
 report \- Create an HTML performance report
 .SH SYNOPSIS
-\fBreport\fR [\fB\-o\fR|\fB\-\-output\fR] [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-m\fR|\fB\-\-measurement\fR] [\fB\-k\fR|\fB\-\-key\-value\fR] [\fB\-f\fR|\fB\-\-filter\fR] [\fB\-s\fR|\fB\-\-separate\-by\fR] [\fB\-a\fR|\fB\-\-aggregate\-by\fR] [\fB\-t\fR|\fB\-\-template\fR] [\fB\-c\fR|\fB\-\-custom\-css\fR] [\fB\-\-title\fR] [\fB\-\-show\-epochs\fR] [\fB\-\-detect\-changes\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBreport\fR [\fB\-o\fR|\fB\-\-output\fR] [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-m\fR|\fB\-\-measurement\fR] [\fB\-k\fR|\fB\-\-key\-value\fR] [\fB\-f\fR|\fB\-\-filter\fR] [\fB\-s\fR|\fB\-\-separate\-by\fR] [\fB\-a\fR|\fB\-\-aggregate\-by\fR] [\fB\-t\fR|\fB\-\-template\fR] [\fB\-c\fR|\fB\-\-custom\-css\fR] [\fB\-\-title\fR] [\fB\-\-show\-epochs\fR] [\fB\-\-show\-changes\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Create an HTML performance report
 .SH OPTIONS
@@ -46,7 +46,7 @@ Custom title for the report (overrides default)
 \fB\-\-show\-epochs\fR
 Show epoch boundary markers in the report (hidden by default, toggleable via legend)
 .TP
-\fB\-\-detect\-changes\fR
+\fB\-\-show\-changes\fR
 Detect and show change points in the report (hidden by default, toggleable via legend)
 .TP
 \fB\-h\fR, \fB\-\-help\fR


### PR DESCRIPTION
## Summary

Rename `detect-changes` to `show-changes` for consistency with other display options

## Type of Change

- [x] `refactor`: Code refactoring (no functional changes)
- [x] `docs`: Documentation update

## Changes

- Renamed `detect-changes` parameter to `show-changes` in GitHub action inputs
- Updated CLI parameter from `--detect-changes` to `--show-changes` for consistency
- Updated all documentation references to reflect the new parameter name
- Updated workflow files to use the new parameter name

## Related Issues

Closes #

## Testing

- [x] All tests pass: `cargo nextest run -- --skip slow`
- [x] Manual testing performed

## Documentation

- [x] Updated relevant documentation (README, guides, manpages)
- [x] Regenerated manpages if CLI changes made: `./scripts/generate-manpages.sh`

## Pre-Submission Checklist

- [x] Code formatted with `cargo fmt`
- [x] Linting passes: `cargo clippy`
- [x] All tests pass: `cargo nextest run -- --skip slow`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format: `type(scope): description`
- [x] Branch is up to date with base branch
- [x] No merge conflicts

## Additional Context

This change makes the parameter naming more consistent with other display options like `show-epochs`, improving the overall API coherence.