### PR TITLE
test: use rstest to run bashtests as separate tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +946,7 @@ dependencies = [
  "rand 0.9.2",
  "readable",
  "regex",
+ "rstest",
  "serde",
  "serde_json",
  "sparklines",
@@ -947,7 +954,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "toml",
- "toml_edit",
+ "toml_edit 0.22.27",
  "unindent",
 ]
 
@@ -959,6 +966,12 @@ dependencies = [
  "chrono",
  "clap",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1570,6 +1583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.9",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "roff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1810,35 @@ dependencies = [
  "serde",
  "serde_derive",
  "typeid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
  "unicode-ident",
 ]
 
@@ -2272,6 +2329,18 @@ dependencies = [
  "indexmap 2.12.1",
  "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
+dependencies = [
+ "indexmap 2.12.1",
+ "toml_datetime 0.7.3",
+ "toml_parser",
  "winnow",
 ]
 

--- a/git_perf/Cargo.toml
+++ b/git_perf/Cargo.toml
@@ -60,6 +60,7 @@ criterion = "0.7.0"
 tempfile = "3.23.0"
 httptest = "0.16.3"
 tokio = { version = "1", features = ["net"] }
+rstest = "0.26.1"
 
 [features]
 vendored-openssl = []

--- a/git_perf/tests/bash_tests.rs
+++ b/git_perf/tests/bash_tests.rs
@@ -1,10 +1,12 @@
 #[cfg(test)]
 mod test {
     use std::env;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
 
-    fn run_bash_tests(start_filter: &str) {
+    use rstest::*;
+
+    fn run_bash_test(bash_file: &Path) {
         let binary_path = Path::new(env!("CARGO_BIN_EXE_git-perf"));
 
         // Prepend binary path to PATH
@@ -17,7 +19,7 @@ mod test {
         // These environment variables ensure tests don't use system/global git config
         // which could have commit signing or other settings that interfere with tests
         let output = Command::new("bash")
-            .args(["../test/run_tests.sh", start_filter])
+            .args([bash_file])
             .env("PATH", new_path)
             .env("GIT_CONFIG_NOSYSTEM", "true")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
@@ -39,13 +41,8 @@ mod test {
         assert!(output.status.success(), "Bash test script failed");
     }
 
-    #[test]
-    fn run_quick_bash_tests_with_binary() {
-        run_bash_tests("test_");
-    }
-
-    #[test]
-    fn run_slow_bash_tests_with_binary() {
-        run_bash_tests("testslow_");
+    #[rstest]
+    fn for_each_file(#[files("../test/test*.sh")] path: PathBuf) {
+        run_bash_test(&path);
     }
 }


### PR DESCRIPTION
## Summary

Refactor bash tests to use rstest for better test organization and execution

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `refactor`: Code refactoring (no functional changes)
- [x] `test`: Test additions or improvements
- [ ] `chore`: Maintenance tasks (dependencies, build, etc.)
- [ ] `perf`: Performance improvement
- [ ] `ci`: CI/CD changes

## Changes

- Added rstest dependency to git_perf/Cargo.toml
- Refactored bash tests to use rstest's file-based test parameterization
- Replaced separate test functions with a single parameterized test that runs each bash test file
- Improved test organization by using the `#[files("../test/test*.sh")]` pattern to automatically discover test files

## Related Issues

Closes #

## Testing

- [x] All tests pass: `cargo nextest run -- --skip slow`
- [x] Added new tests for changes
- [x] Manual testing performed

**Test results:**
```bash
# All bash tests now run individually through rstest
```

## Documentation

- [x] No documentation changes needed

## Additional Context

This change improves the test organization by using rstest's file discovery capabilities to automatically find and run all bash test files. This makes it easier to add new bash tests in the future without having to modify the test runner code.