### PR TITLE
fix: use relative action references for consistency across invoked actions

### DIFF
--- a/.github/actions/cleanup/action.yml
+++ b/.github/actions/cleanup/action.yml
@@ -41,11 +41,29 @@ runs:
         git config --global user.name "GitHub Actions Bot"
         git config --global user.email "actions@github.com"
 
-    - name: Install git-perf
-      if: inputs.git-perf-version != 'skip'
+    - name: Install git-perf (from branch - internal testing)
+      if: ${{ inputs.git-perf-version == 'branch' }}
       uses: ./.github/actions/install
       with:
-        release: ${{ inputs.git-perf-version }}
+        release: 'branch'
+
+    - name: Install git-perf (from release - external usage)
+      if: ${{ inputs.git-perf-version != 'skip' && inputs.git-perf-version != 'branch' }}
+      shell: bash
+      run: |
+        latest=""
+        version=""
+        if [ "${{ inputs.git-perf-version }}" = "latest" ]; then
+          latest="latest/"
+        else
+          version="${{ inputs.git-perf-version }}/"
+        fi
+        download_url="https://github.com/kaihowl/git-perf/releases/${latest}download/${version}git-perf-installer.sh"
+        echo "Downloading $download_url"
+        curl --proto '=https' --tlsv1.2 -LsSf "$download_url" | sh
+        export PATH=$HOME/.cargo/bin:$PATH
+        git-perf --help
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Fetch performance notes
       shell: bash

--- a/.github/actions/report/action.yml
+++ b/.github/actions/report/action.yml
@@ -92,10 +92,29 @@ runs:
           echo "✓ Using root directory (no subdirectory specified)"
         fi
 
-    - name: Install git-perf
+    - name: Install git-perf (from branch - internal testing)
+      if: ${{ inputs.git-perf-version == 'branch' }}
       uses: ./.github/actions/install
       with:
-        release: ${{ inputs.git-perf-version }}
+        release: 'branch'
+
+    - name: Install git-perf (from release - external usage)
+      if: ${{ inputs.git-perf-version != 'branch' }}
+      shell: bash
+      run: |
+        latest=""
+        version=""
+        if [ "${{ inputs.git-perf-version }}" = "latest" ]; then
+          latest="latest/"
+        else
+          version="${{ inputs.git-perf-version }}/"
+        fi
+        download_url="https://github.com/kaihowl/git-perf/releases/${latest}download/${version}git-perf-installer.sh"
+        echo "Downloading $download_url"
+        curl --proto '=https' --tlsv1.2 -LsSf "$download_url" | sh
+        export PATH=$HOME/.cargo/bin:$PATH
+        git-perf --help
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v5


### PR DESCRIPTION
## Summary

For external use: Inline the single install step to ensure that the install logic of the same version as the action is used.

For internal use: Use relative includes to use the current branch install logic, which is more than 1 single step.

Using relative paths for composite actions in GitHub is not directly supported. A relative include would reference the external/main repo's paths instead of the action's paths.

## Type of Change

- [x] `fix`: Bug fix
- [x] `ci`: CI/CD changes

## Changes

- Updated `.github/actions/cleanup/action.yml` to use local install action instead of `kaihowl/git-perf/.github/actions/install@master`
- Updated `.github/actions/report/action.yml` to use local install action instead of `kaihowl/git-perf/.github/actions/install@master`

## Testing

- [x] CI workflow runs successfully with the updated action references

## Additional Context

This change ensures that the install action used by both cleanup and report actions is always consistent with the current branch version, preventing potential compatibility issues when actions are updated.