### PR TITLE
ci: run nextest with --no-fail-fast flag to capture all test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       run: cargo build --verbose
 
     - name: Run tests
-      run: cargo nextest run --verbose
+      run: cargo nextest run --no-fail-fast --verbose
 
     - name: Run fibonacci benchmarks and track performance
       env:

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -106,7 +106,7 @@ jobs:
         run: cargo build --verbose ${{ env.TARGET_FLAGS }}
 
       - name: Run tests
-        run: cargo nextest run --verbose ${{ env.TARGET_FLAGS }}
+        run: cargo nextest run --no-fail-fast --verbose ${{ env.TARGET_FLAGS }}
 
       - name: Test Git language interface compatibility
         # This test verifies that git-perf correctly sets comprehensive locale settings internally
@@ -118,21 +118,21 @@ jobs:
           # Test with default C locale (should work as expected)
           echo "=== Testing with C locale ==="
           LANG=C LC_ALL=C LANGUAGE=C git --version
-          cargo nextest run --verbose ${{ env.TARGET_FLAGS }}
+          cargo nextest run --no-fail-fast --verbose ${{ env.TARGET_FLAGS }}
                     
           # Test with German locale (should still work due to explicit locale settings in git-perf)
           echo "=== Testing with German locale ==="
           LANG=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 LANGUAGE=de_DE git --version
-          cargo nextest run --verbose ${{ env.TARGET_FLAGS }}
+          cargo nextest run --no-fail-fast --verbose ${{ env.TARGET_FLAGS }}
                     
           # Test with Japanese locale (should still work due to explicit locale settings in git-perf)
           echo "=== Testing with Japanese locale ==="
           LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 LANGUAGE=ja_JP git --version
-          cargo nextest run --verbose ${{ env.TARGET_FLAGS }}
+          cargo nextest run --no-fail-fast --verbose ${{ env.TARGET_FLAGS }}
                     
           # Test with French locale (should still work due to explicit locale settings in git-perf)
           echo "=== Testing with French locale ==="
           LANG=fr_FR.UTF-8 LC_ALL=fr_FR.UTF-8 LANGUAGE=fr_FR git --version
-          cargo nextest run --verbose ${{ env.TARGET_FLAGS }}
+          cargo nextest run --no-fail-fast --verbose ${{ env.TARGET_FLAGS }}
           
           echo "All language compatibility tests passed!"

--- a/.github/workflows/pre-release-slow-tests.yml
+++ b/.github/workflows/pre-release-slow-tests.yml
@@ -73,7 +73,7 @@ jobs:
         echo ""
 
         # Run the slow bash test using cargo nextest with the scale factor
-        if cargo nextest run run_slow_bash_tests_with_binary --lib --test bash_tests; then
+        if cargo nextest run --no-fail-fast run_slow_bash_tests_with_binary --lib --test bash_tests; then
             echo ""
             echo "================================================"
             echo "🎉 SUCCESS: Slow tests passed with scale factor $ITERATION_SCALE_FACTOR!"


### PR DESCRIPTION
## Summary
- Run cargo nextest with --no-fail-fast in CI to surface all test failures instead of stopping at the first failure.

## Changes
- Update Nextest invocation to include --no-fail-fast across CI workflows:
  - .github/workflows/ci.yml: cargo nextest run --no-fail-fast --verbose
  - .github/workflows/compat.yml: cargo nextest run --no-fail-fast --verbose ${{ env.TARGET_FLAGS }}
  - .github/workflows/pre-release-slow-tests.yml:
    - Updated slow-test invocation to: cargo nextest run --no-fail-fast run_slow_bash_tests_with_binary --lib --test bash_tests

## Rationale
- enables full visibility into all failing tests in CI by not aborting on the first failure.
- Helps with triage by surfacing multiple issues in a single run.

## Testing plan
- Review the updated workflow files to confirm the --no-fail-fast flag is present in all Nextest invocations.
- Trigger a CI run to observe that failures are not aborted early and that failures are reported comprehensively.

## Potential impact
- Slightly longer CI runs if multiple tests fail, due to not short-circuiting on the first failure.
- More verbose failure output, aiding debugging and triage.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/08dcb909-3390-4e61-b2f1-fb44d8faa6d2