### PR TITLE
fix(test): prevent assert_success_with_output from aborting early on failure

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -303,8 +303,11 @@ assert_success_with_output() {
   local _cmd_output
   local exit_code
 
+  set +e
   _cmd_output=$("$@" 2>&1)
   exit_code=$?
+  set -e
+
   eval "$output_var=\$_cmd_output"
 
   if [[ $exit_code -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Temporarily disable errexit around command execution in assert_success_with_output to capture output even when the command fails
- Re-enable strict error handling after capture to preserve test behavior

## Changes
### Test Utilities
- In test/common.sh, modify assert_success_with_output:
  - Add set +e before executing the command
  - Capture combined output with 2>&1
  - Restore error handling with set -e after capture

### Rationale
- Prevents premature test aborts on non-zero exit codes
- Enables reliable assertion of exit codes and captured output

## Test plan
- [x] Run full test suite to ensure no regressions
- [x] Validate that failing commands no longer abort test runner immediately
- [x] Confirm output is captured correctly for both success and failure scenarios

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/30b62232-35be-4ec4-9ae3-3ab17d1acb8b