### PR TITLE
test(bash_tests): make assertions specific in test_operations_without_seed.sh

### DIFF
--- a/test/test_operations_without_seed.sh
+++ b/test/test_operations_without_seed.sh
@@ -25,57 +25,21 @@ git push > /dev/null 2>&1
 
 test_section "Testing remove operation without seed measurements"
 
-# Test remove operation without any measurements (should handle gracefully or fail with expected message)
-# Note: We use a compound test here since either success or specific error is acceptable
-if git perf remove --older-than '7d' > /dev/null 2>&1; then
-    # Operation succeeded - that's acceptable behavior
-    true
-else
-    # Operation failed - check for expected error messages
-    assert_failure_with_output output git perf remove --older-than '7d'
-    # Either of these messages is acceptable
-    if [[ $output != *'No performance measurements found'* ]] && [[ $output != *'This repo does not have any measurements'* ]]; then
-        # If neither expected message is present, we still accept it as implementation-specific
-        true
-    fi
-fi
+# Test remove operation without any measurements - should fail with expected error
+assert_failure_with_output output git perf remove --older-than '7d'
+assert_contains "$output" "Remote repository is empty" "Expected error about empty remote repository"
 
 test_section "Testing prune operation without seed measurements"
 
-# Test prune operation without any measurements (should handle gracefully or fail with expected message)
-if git perf prune > /dev/null 2>&1; then
-    # Operation succeeded - that's acceptable behavior
-    true
-else
-    # Operation failed - check for expected error messages
-    assert_failure_with_output output git perf prune
-    # Either of these messages is acceptable
-    if [[ $output != *'No performance measurements found'* ]] && [[ $output != *'This repo does not have any measurements'* ]]; then
-        # If neither expected message is present, we still accept it as implementation-specific
-        true
-    fi
-fi
+# Test prune operation without any measurements - should fail with expected error
+assert_failure_with_output output git perf prune
+assert_contains "$output" "Remote repository is empty" "Expected error about empty remote repository"
 
 test_section "Testing report operation without seed measurements"
 
-# Test report operation without any measurements (should handle gracefully)
-if git perf report -o - > /dev/null 2>&1; then
-    # Operation succeeded - verify it returns empty or minimal output
-    assert_success_with_output output git perf report -o -
-    report_lines=$(echo "$output" | wc -l)
-    # Empty result is acceptable (0 or 1 line with only whitespace)
-    if [[ $report_lines -eq 0 ]] || [[ $report_lines -eq 1 && -z "$(echo "$output" | tr -d '[:space:]')" ]]; then
-        true
-    fi
-else
-    # Operation failed - check for expected error message
-    assert_failure_with_output output git perf report -o -
-    # This message is acceptable
-    if [[ $output != *'No performance measurements found'* ]]; then
-        # Other error messages are also acceptable for this edge case
-        true
-    fi
-fi
+# Test report operation without any measurements - should fail with expected error
+assert_failure_with_output output git perf report -o -
+assert_contains "$output" "No performance measurements found" "Expected error about no measurements"
 
 popd > /dev/null  # exit work_noseed
 


### PR DESCRIPTION
## Summary

Fixes #575 by replacing vague conditional logic with explicit assertions in `test_operations_without_seed.sh`.

**Changes:**
- Removed guarded if statements that allowed commands to succeed or fail with different error messages
- Added specific assertions using `assert_failure_with_output` and `assert_contains` 
- Test now expects exact error messages:
  - `git perf remove --older-than '7d'`: Must fail with "Remote repository is empty"
  - `git perf prune`: Must fail with "Remote repository is empty"
  - `git perf report -o -`: Must fail with "No performance measurements found"

**Before:** Test allowed multiple behaviors (success or various error messages), making it non-specific
**After:** Test requires specific failure modes with exact error messages

This makes the test more maintainable and will catch regressions in error messaging.

## Test plan

- [x] Verified test passes: `cargo test --test bash_tests -- test_operations_without_seed`
- [x] Test now has specific assertions instead of conditional logic
- [x] Error messages match actual behavior of git-perf commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)