### PR TITLE
CI: adopt PR 586 changes in report action audit args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
         with:
           depth: 40
           additional-args: '-s rust'
-          audit-args: '-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m release-binary-size -s os="ubuntu-22.04" -s rust="stable"'
+          audit-args: '-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m release-binary-size --separate-by os --separate-by rust'
           git-perf-version: 'skip'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           show-size: 'true'


### PR DESCRIPTION
## Summary
- Align CI report action with PR 586 changes
- Switch audit args to separate-by grouping for OS and Rust

## Changes
### CI Workflow
- Updated .github/workflows/ci.yml audit-args from explicit OS/Rust constraints to use `--separate-by os` and `--separate-by rust` (retains existing metrics)
- Keeps the same metric set: `-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m release-binary-size` with the new separation options

## Rationale
- Implements the consolidated auditing approach introduced in PR 586 for the report action, simplifying OS/Rust breakdown configuration.

## Test plan
- [x] CI workflow runs successfully and the audit step uses the new `--separate-by` flags
- [x] Audit output is grouped by OS and Rust as intended
- [x] No regression in the reported metrics

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d1fc8b90-6c5c-4fb1-8fbb-626fa747d222