### PR TITLE
Refactor git module to isolate fresh write ref for reset and status

### DIFF
--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -466,6 +466,51 @@ pub enum Commands {
     /// Will refuse to work if run on a shallow clone.
     Prune {},
 
+    /// Show pending measurements that haven't been pushed
+    ///
+    /// Lists local measurements that exist in write branches but haven't been
+    /// pushed to the remote repository. Similar to `git status` for tracking
+    /// which changes are pending.
+    ///
+    /// Pending measurements are those created with `add`, `measure`, or `import`
+    /// that haven't been published via `push`. These can be safely discarded
+    /// with the `reset` command.
+    ///
+    /// Examples:
+    ///   git perf status                    # Show summary of pending measurements
+    ///   git perf status --detailed         # Show per-commit breakdown
+    Status {
+        /// Show detailed per-commit breakdown
+        #[arg(short, long)]
+        detailed: bool,
+    },
+
+    /// Drop locally pending measurements that haven't been pushed
+    ///
+    /// Removes measurements from local write branches that haven't been pushed
+    /// to the remote repository. This is useful for discarding test or debug
+    /// measurements before publishing.
+    ///
+    /// IMPORTANT: This only affects local pending measurements. Measurements that
+    /// have been pushed to the remote are not affected. Use `remove` or `prune`
+    /// for managing published measurements.
+    ///
+    /// Removes ALL pending measurements.
+    ///
+    /// Examples:
+    ///   git perf reset                        # Remove all pending measurements
+    ///   git perf reset --dry-run              # Preview what would be reset
+    ///   git perf reset --force                # Skip confirmation prompt
+    Reset {
+        /// Preview what would be reset without actually resetting
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Skip confirmation prompt (dangerous)
+        #[arg(short, long)]
+        force: bool,
+    },
+
     /// List all commits that have performance measurements.
     ///
     /// Outputs one commit SHA-1 hash per line. This can be used to identify

--- a/git_perf/src/cli.rs
+++ b/git_perf/src/cli.rs
@@ -13,8 +13,10 @@ use crate::git::git_interop::{list_commits_with_measurements, prune, pull, push}
 use crate::import::{handle_import, ImportOptions};
 use crate::measurement_storage::{add_to_commit as add, remove_measurements_from_commits};
 use crate::reporting::report;
+use crate::reset;
 use crate::size;
 use crate::stats::ReductionFunc;
+use crate::status;
 use git_perf_cli_types::{Cli, Commands};
 
 pub fn handle_calls() -> Result<()> {
@@ -171,6 +173,8 @@ pub fn handle_calls() -> Result<()> {
             Ok(())
         }
         Commands::Prune {} => prune(),
+        Commands::Status { detailed } => status::show_status(detailed),
+        Commands::Reset { dry_run, force } => reset::reset_measurements(dry_run, force),
         Commands::Remove {
             older_than,
             no_prune,

--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -267,7 +267,9 @@ fn fetch(work_dir: Option<&Path>) -> Result<(), GitError> {
     Ok(())
 }
 
-fn reconcile_branch_with(target: &str, branch: &str) -> Result<(), GitError> {
+/// Merges notes from one branch into a target using the cat_sort_uniq strategy.
+/// This is used to consolidate measurements from multiple write refs.
+pub(crate) fn reconcile_branch_with(target: &str, branch: &str) -> Result<(), GitError> {
     _ = capture_git_output(
         &[
             "notes",
@@ -570,6 +572,10 @@ fn remove_measurements_from_reference(
     Ok(())
 }
 
+/// Creates a new write ref and updates the symbolic ref to point to it.
+/// This is used to ensure concurrent writes go to a new location, preventing
+/// race conditions during operations like reset or push.
+/// Internal version that returns GitError.
 fn new_symbolic_write_ref() -> Result<String, GitError> {
     let target = create_temp_ref_name(REFS_NOTES_WRITE_TARGET_PREFIX);
 
@@ -578,6 +584,13 @@ fn new_symbolic_write_ref() -> Result<String, GitError> {
     // that go to the old target will still be merged during consolidation
     git_symbolic_ref_create_or_update(REFS_NOTES_WRITE_SYMBOLIC_REF, &target)?;
     Ok(target)
+}
+
+/// Creates a new write ref and updates the symbolic ref to point to it (public wrapper).
+/// This is used to ensure concurrent writes go to a new location, preventing
+/// race conditions during operations like reset or push.
+pub(crate) fn create_new_write_ref() -> Result<String> {
+    new_symbolic_write_ref().map_err(|e| anyhow!("{:?}", e))
 }
 
 const EMPTY_OID: &str = "0000000000000000000000000000000000000000";
@@ -806,6 +819,15 @@ pub fn create_consolidated_read_branch() -> Result<ReadBranchGuard> {
     Ok(ReadBranchGuard { temp_ref })
 }
 
+/// Creates a temporary read branch that consolidates ONLY pending writes (excludes remote).
+/// This is used by status and reset commands to see only local pending measurements.
+/// The returned guard must be kept alive for as long as the reference is needed.
+/// The temporary reference is automatically cleaned up when the guard is dropped.
+pub(crate) fn create_consolidated_pending_read_branch() -> Result<ReadBranchGuard> {
+    let temp_ref = update_pending_read_branch()?;
+    Ok(ReadBranchGuard { temp_ref })
+}
+
 fn get_refs(additional_args: Vec<String>) -> Result<Vec<Reference>, GitError> {
     let mut args = vec!["for-each-ref", "--format=%(refname)%00%(objectname)"];
     args.extend(additional_args.iter().map(|s| s.as_str()));
@@ -864,6 +886,22 @@ fn update_read_branch() -> Result<TempRef> {
 
     consolidate_write_branches_into(&current_upstream_oid, &temp_ref.ref_name, None)
         .map_err(|e| anyhow!("Failed to consolidate write branches: {:?}", e))?;
+
+    Ok(temp_ref)
+}
+
+fn update_pending_read_branch() -> Result<TempRef> {
+    let temp_ref = TempRef::new(REFS_NOTES_READ_PREFIX)
+        .map_err(|e| anyhow!("Failed to create temporary ref: {:?}", e))?;
+    // Create a read branch from ONLY the pending write branches (not the remote).
+    // Start with empty tree and merge in all write refs.
+    let refs = get_refs(vec![format!("{REFS_NOTES_WRITE_TARGET_PREFIX}*")])
+        .map_err(|e| anyhow!("Failed to get write refs: {:?}", e))?;
+
+    for reference in &refs {
+        reconcile_branch_with(&temp_ref.ref_name, &reference.oid)
+            .map_err(|e| anyhow!("Failed to merge write ref: {:?}", e))?;
+    }
 
     Ok(temp_ref)
 }
@@ -1046,6 +1084,18 @@ pub fn push(work_dir: Option<&Path>, remote: Option<&str>) -> Result<()> {
     })?;
 
     Ok(())
+}
+
+/// Get all write refs and return their names and OIDs
+pub(crate) fn get_write_refs() -> Result<Vec<(String, String)>> {
+    let refs = get_refs(vec![format!("{REFS_NOTES_WRITE_TARGET_PREFIX}*")])
+        .map_err(|e| anyhow!("{:?}", e))?;
+    Ok(refs.into_iter().map(|r| (r.refname, r.oid)).collect())
+}
+
+/// Delete a git reference (wrapper that converts GitError to anyhow::Error)
+pub(crate) fn delete_reference(ref_name: &str) -> Result<()> {
+    remove_reference(ref_name).map_err(|e| anyhow!("{:?}", e))
 }
 
 #[cfg(test)]

--- a/git_perf/src/lib.rs
+++ b/git_perf/src/lib.rs
@@ -15,9 +15,11 @@ pub mod measurement_storage;
 pub mod parsers;
 pub mod reporting;
 pub mod reporting_config;
+pub mod reset;
 pub mod serialization;
 pub mod size;
 pub mod stats;
+pub mod status;
 pub mod units;
 
 // Test helpers module - made public for use in unit tests, integration tests, and benchmarks

--- a/git_perf/src/reset.rs
+++ b/git_perf/src/reset.rs
@@ -1,0 +1,153 @@
+use crate::git::git_interop::{
+    create_consolidated_pending_read_branch, create_new_write_ref, delete_reference,
+    get_write_refs, walk_commits,
+};
+use crate::serialization::deserialize;
+use anyhow::{Context, Result};
+use std::io::{self, Write};
+
+/// Information about what will be reset
+#[derive(Debug)]
+pub struct ResetPlan {
+    /// References that will be deleted
+    pub refs_to_delete: Vec<String>,
+
+    /// Number of measurements that will be removed
+    pub measurement_count: usize,
+
+    /// Number of commits affected
+    pub commit_count: usize,
+}
+
+/// Reset (discard) pending measurements
+pub fn reset_measurements(dry_run: bool, force: bool) -> Result<()> {
+    // CRITICAL: Create a fresh write ref FIRST, before gathering refs to delete.
+    // This ensures that any concurrent measurements added during the reset operation
+    // will go to the new write ref and won't be accidentally deleted.
+    let new_write_ref = create_new_write_ref().context("Failed to create fresh write ref")?;
+
+    // Now gather the refs to delete (this will NOT include the new write ref we just created)
+    let plan = plan_reset(&new_write_ref)?;
+
+    // Check if there's anything to reset
+    if plan.refs_to_delete.is_empty() {
+        println!("No pending measurements to reset.");
+        return Ok(());
+    }
+
+    // Display plan
+    display_reset_plan(&plan)?;
+
+    // Get confirmation unless force or dry-run
+    if !dry_run && !force && !confirm_reset()? {
+        println!("Reset cancelled.");
+        return Ok(());
+    }
+
+    // Execute reset (unless dry-run)
+    if dry_run {
+        println!();
+        println!("Dry run - no changes made.");
+    } else {
+        execute_reset(&plan)?;
+        println!();
+        println!(
+            "Reset complete. {} write ref(s) deleted.",
+            plan.refs_to_delete.len()
+        );
+    }
+
+    Ok(())
+}
+
+/// Plan what will be reset
+///
+/// The new_write_ref parameter is the ref we just created, which should NOT be deleted.
+fn plan_reset(new_write_ref: &str) -> Result<ResetPlan> {
+    // Get all write refs
+    let refs = get_write_refs()?;
+
+    // Filter out the new write ref we just created
+    let refs_to_delete: Vec<String> = refs
+        .into_iter()
+        .map(|(refname, _)| refname)
+        .filter(|refname| refname != new_write_ref)
+        .collect();
+
+    if refs_to_delete.is_empty() {
+        return Ok(ResetPlan {
+            refs_to_delete: vec![],
+            measurement_count: 0,
+            commit_count: 0,
+        });
+    }
+
+    // Count measurements for display
+    let (measurement_count, commit_count) = count_all_pending_measurements()?;
+
+    Ok(ResetPlan {
+        refs_to_delete,
+        measurement_count,
+        commit_count,
+    })
+}
+
+/// Count all pending measurements
+fn count_all_pending_measurements() -> Result<(usize, usize)> {
+    // Create consolidated pending branch using git module function
+    let _guard = create_consolidated_pending_read_branch()?;
+    // Use a large but reasonable number instead of usize::MAX to avoid overflow issues
+    let commits = walk_commits(1_000_000)?;
+
+    let mut total_measurements = 0;
+    let mut commit_count = 0;
+
+    for commit_with_notes in commits {
+        if commit_with_notes.note_lines.is_empty() {
+            continue;
+        }
+
+        let note_text = commit_with_notes.note_lines.join("\n");
+        let measurements = deserialize(&note_text);
+        if !measurements.is_empty() {
+            total_measurements += measurements.len();
+            commit_count += 1;
+        }
+    }
+
+    Ok((total_measurements, commit_count))
+}
+
+/// Execute the reset plan
+fn execute_reset(plan: &ResetPlan) -> Result<()> {
+    // Delete all the old write refs
+    // The new write ref was already created before planning, so it won't be in this list
+    for ref_name in &plan.refs_to_delete {
+        delete_reference(ref_name)
+            .with_context(|| format!("Failed to delete reference: {}", ref_name))?;
+    }
+
+    Ok(())
+}
+
+/// Display what will be reset
+fn display_reset_plan(plan: &ResetPlan) -> Result<()> {
+    println!("Will reset:");
+    println!("  {} write ref(s)", plan.refs_to_delete.len());
+    println!("  {} measurement(s)", plan.measurement_count);
+    println!("  {} commit(s) with measurements", plan.commit_count);
+
+    Ok(())
+}
+
+/// Prompt user for confirmation
+fn confirm_reset() -> Result<bool> {
+    print!("Are you sure you want to discard these pending measurements? [y/N] ");
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    let response = input.trim().to_lowercase();
+    Ok(response == "y" || response == "yes")
+}

--- a/git_perf/src/status.rs
+++ b/git_perf/src/status.rs
@@ -1,0 +1,149 @@
+use crate::git::git_interop::{create_consolidated_pending_read_branch, walk_commits};
+use crate::serialization::deserialize;
+use anyhow::Result;
+use std::collections::HashSet;
+
+/// Information about pending measurements
+#[derive(Debug)]
+pub struct PendingStatus {
+    /// Total number of commits with pending measurements
+    pub commit_count: usize,
+
+    /// Unique measurement names found in pending writes
+    pub measurement_names: HashSet<String>,
+
+    /// Per-commit breakdown (if detailed)
+    pub per_commit: Option<Vec<CommitMeasurements>>,
+}
+
+/// Measurements for a specific commit
+#[derive(Debug)]
+pub struct CommitMeasurements {
+    /// Commit SHA
+    pub commit: String,
+
+    /// Commit title
+    pub title: String,
+
+    /// Measurement names in this commit
+    pub measurement_names: Vec<String>,
+
+    /// Number of measurements in this commit
+    pub count: usize,
+}
+
+/// Display pending measurement status
+pub fn show_status(detailed: bool) -> Result<()> {
+    // 1. Check if there are any pending measurements
+    let status = gather_pending_status(detailed)?;
+
+    // 2. Display results
+    display_status(&status, detailed)?;
+
+    Ok(())
+}
+
+/// Gather information about pending measurements
+fn gather_pending_status(detailed: bool) -> Result<PendingStatus> {
+    // Create a consolidated read branch that includes pending writes
+    // but not the remote branch - using git module function
+    let _pending_guard = create_consolidated_pending_read_branch()?;
+
+    // Walk all commits to find measurements
+    // Use a large but reasonable number instead of usize::MAX to avoid overflow issues
+    let commits = walk_commits(1_000_000)?;
+
+    let mut commit_count = 0;
+    let mut all_measurement_names = HashSet::new();
+    let mut per_commit = if detailed { Some(Vec::new()) } else { None };
+
+    for commit_with_notes in commits {
+        if commit_with_notes.note_lines.is_empty() {
+            continue;
+        }
+
+        // Deserialize measurements from note
+        let note_text = commit_with_notes.note_lines.join("\n");
+        let measurements = deserialize(&note_text);
+
+        if measurements.is_empty() {
+            continue;
+        }
+
+        commit_count += 1;
+
+        // Collect unique measurement names
+        let commit_measurement_names: Vec<String> =
+            measurements.iter().map(|m| m.name.clone()).collect();
+
+        for name in &commit_measurement_names {
+            all_measurement_names.insert(name.clone());
+        }
+
+        // Store per-commit details if requested
+        if let Some(ref mut per_commit_vec) = per_commit {
+            per_commit_vec.push(CommitMeasurements {
+                commit: commit_with_notes.sha.clone(),
+                title: commit_with_notes.title.clone(),
+                measurement_names: commit_measurement_names,
+                count: measurements.len(),
+            });
+        }
+    }
+
+    Ok(PendingStatus {
+        commit_count,
+        measurement_names: all_measurement_names,
+        per_commit,
+    })
+}
+
+/// Display status information to stdout
+fn display_status(status: &PendingStatus, detailed: bool) -> Result<()> {
+    if status.commit_count == 0 {
+        println!("No pending measurements.");
+        println!("(use \"git perf add\" or \"git perf measure\" to add measurements)");
+        return Ok(());
+    }
+
+    println!("Pending measurements:");
+    println!("  {} commit(s) with measurements", status.commit_count);
+    println!("  {} unique measurement(s)", status.measurement_names.len());
+    println!();
+
+    if !status.measurement_names.is_empty() {
+        println!("Measurement names:");
+        let mut sorted_names: Vec<_> = status.measurement_names.iter().collect();
+        sorted_names.sort();
+        for name in sorted_names {
+            println!("  - {}", name);
+        }
+        println!();
+    }
+
+    if detailed {
+        if let Some(ref per_commit) = status.per_commit {
+            println!("Per-commit breakdown:");
+            for commit_info in per_commit {
+                let short_sha = if commit_info.commit.len() >= 12 {
+                    &commit_info.commit[..12]
+                } else {
+                    &commit_info.commit
+                };
+                println!(
+                    "  {} ({} measurement(s)) - {}",
+                    short_sha, commit_info.count, commit_info.title
+                );
+                for name in &commit_info.measurement_names {
+                    println!("    - {}", name);
+                }
+            }
+            println!();
+        }
+    }
+
+    println!("(use \"git perf reset\" to discard pending measurements)");
+    println!("(use \"git perf push\" to publish measurements)");
+
+    Ok(())
+}

--- a/test/test_reset.sh
+++ b/test/test_reset.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+script_dir=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
+source "$script_dir/common.sh"
+
+## Test git perf reset functionality
+
+cd_empty_repo
+create_commit
+
+echo "Test 1: Reset with no pending measurements"
+output=$(git perf reset --force)
+assert_output_contains "$output" "No pending measurements" "Expected empty reset"
+
+echo "Test 2: Dry run"
+git perf add -m test-measure 10.0
+output=$(git perf reset --dry-run)
+assert_output_contains "$output" "Dry run" "Expected dry-run indicator"
+# Verify measurements still exist
+output=$(git perf status)
+assert_output_contains "$output" "test-measure" "Expected measurements to remain after dry-run"
+
+echo "Test 3: Force reset"
+git perf reset --force
+output=$(git perf status)
+assert_output_contains "$output" "No pending measurements" "Expected empty after reset"
+
+echo "Test 4: Multiple measurements and commits"
+create_commit
+git perf add -m measure1 100.0
+create_commit
+git perf add -m measure2 200.0
+git perf add -m measure3 300.0
+
+output=$(git perf status)
+assert_output_contains "$output" "2 commit(s)" "Expected 2 commits with measurements"
+
+# Reset should clear all
+git perf reset --force
+output=$(git perf status)
+assert_output_contains "$output" "No pending measurements" "Expected empty after reset"
+
+echo "All reset tests passed!"

--- a/test/test_status.sh
+++ b/test/test_status.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+script_dir=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
+source "$script_dir/common.sh"
+
+## Test git perf status functionality
+
+cd_empty_repo
+create_commit
+
+echo "Test 1: No pending measurements"
+output=$(git perf status)
+assert_output_contains "$output" "No pending measurements" "Expected empty status"
+
+echo "Test 2: Add measurements and check status"
+git perf add -m test-measure 10.0
+output=$(git perf status)
+assert_output_contains "$output" "1 commit(s)" "Expected 1 commit"
+assert_output_contains "$output" "test-measure" "Expected measurement name"
+
+echo "Test 3: Multiple measurements"
+git perf add -m another-measure 20.0
+output=$(git perf status)
+assert_output_contains "$output" "2 unique measurement(s)" "Expected 2 measurements"
+assert_output_contains "$output" "test-measure" "Expected test-measure"
+assert_output_contains "$output" "another-measure" "Expected another-measure"
+
+echo "Test 4: Multiple commits with measurements"
+create_commit
+git perf add -m test-measure 15.0
+output=$(git perf status)
+assert_output_contains "$output" "2 commit(s)" "Expected 2 commits"
+
+echo "Test 5: Detailed output"
+output=$(git perf status --detailed)
+assert_output_contains "$output" "Per-commit breakdown" "Expected detailed view"
+
+echo "All status tests passed!"


### PR DESCRIPTION
## Summary
This PR refactors the git module to isolate fresh write ref creation during reset, adds pending measurements status reporting, and introduces new CLI commands and internal APIs to support reset and status workflows without races.

## Changes
- Core functionality
  - Add reset.rs with reset_measurements:
    - Creates a fresh write ref up front to avoid races when concurrent measurements are written during reset
    - Builds a plan of refs to delete and measurement counts
    - Supports dry-run and force options, with user confirmation
    - Executes reset and reports results
  - Add status.rs with pending status reporting:
    - Scans pending write refs and reports commits with measurements
    - Optional detailed per-commit breakdown
    - Lists unique measurement names and provides a final summary
  - Git interop improvements
    - create_new_write_ref: public wrapper to create a new fresh write ref
    - create_consolidated_pending_read_branch: builds a read view containing only pending writes (no remote)
    - get_write_refs: fetches all write refs and their OIDs
    - delete_reference: wrapper to remove a git reference with proper error mapping
    - reconcile_branch_with: now documented as part of a strategy to consolidate notes from write refs
  - CLI integration
    - Expose status and reset commands in the CLI
    - git perf status supports --detailed; git perf reset supports --dry-run and --force
  - Public API exposure
    - Export reset and status modules in git_perf/src/lib.rs
- Testing
  - Add test_reset.sh and test_status.sh to exercise reset and status workflows in integration tests

## Rationale
Isolating fresh write ref creation prevents race conditions when new measurements are added during a reset. Introducing a dedicated status command provides visibility into pending measurements, while the new reset flow ensures safe garbage collection of local pending refs without affecting the freshly created write ref.

## Migration and compatibility
- No breaking API changes for existing users beyond new capabilities (dry-run, detailed status, etc.).
- New commands and options are opt-in enhancements; existing behavior remains supported.

## How to test
- Run unit/integration tests: cargo test
- Or run the new test scripts:
  - test/test_status.sh
  - test/test_reset.sh
- Manual flow:
  - git perf status to view pending measurements
  - git perf reset --dry-run to preview
  - git perf reset --force to apply reset
  - Ensure after reset that pending measurements are cleared and a new write ref exists for future writes

## Related issues
- Addresses potential race conditions when multiple writers produce measurements concurrently during reset
- Improves observability of pending measurements through status output

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/26d99a75-53a6-46a4-8855-79b42761836e