### PR TITLE
fix: skipping audit due to missing history is info and not error

### DIFF
--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Result};
 use itertools::Itertools;
-use log::error;
+use log::info;
 use sparklines::spark;
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -400,7 +400,7 @@ fn audit_with_data(
         let number_measurements = tail_summary.len;
         // MUTATION POINT: > vs < (Line 122)
         let plural_s = if number_measurements == 1 { "" } else { "s" };
-        error!("Only {number_measurements} historical measurement{plural_s} found. Less than requested min_measurements of {min_count}. Skipping test.");
+        info!("Only {number_measurements} historical measurement{plural_s} found. Less than requested min_measurements of {min_count}. Skipping test.");
 
         let mut skip_message = format!(
             "⏭️ '{measurement}'\nOnly {number_measurements} historical measurement{plural_s} found. Less than requested min_measurements of {min_count}. Skipping test."


### PR DESCRIPTION
## Summary

Change log level from `error` to `info` for messages about skipping tests due to insufficient historical measurements.

## Type of Change

- [x] `fix`: Bug fix

## Changes

- Changed log level from `error` to `info` in `audit.rs` for messages about insufficient historical measurements
- Updated import statement from `log::error` to `log::info`
- This prevents misleading error logs when tests are skipped due to expected conditions

## Related Issues

Closes #

## Testing

- [x] All tests pass: `cargo nextest run -- --skip slow`
- [ ] Added new tests for changes
- [x] Manual testing performed

## Documentation

- [x] No documentation changes needed

## Pre-Submission Checklist

- [x] Code formatted with `cargo fmt`
- [x] Linting passes: `cargo clippy`
- [x] All tests pass: `cargo nextest run -- --skip slow`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format: `type(scope): description`
- [x] Branch is up to date with base branch
- [x] No merge conflicts