### PR TITLE
docs: use latest tag in docs consistently

### DIFF
--- a/.github/actions/cleanup/README.md
+++ b/.github/actions/cleanup/README.md
@@ -36,14 +36,14 @@ jobs:
           fetch-depth: 0  # Full checkout required for git perf operations
 
       - name: Cleanup measurements
-        uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+        uses: kaihowl/git-perf/.github/actions/cleanup@latest
 ```
 
 ### Custom Retention Period
 
 ```yaml
 - name: Cleanup measurements (retain 30 days)
-  uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/cleanup@latest
   with:
     retention-days: 30
 ```
@@ -52,7 +52,7 @@ jobs:
 
 ```yaml
 - name: Cleanup measurements (no backup)
-  uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/cleanup@latest
   with:
     backup: false
 ```
@@ -61,7 +61,7 @@ jobs:
 
 ```yaml
 - name: Cleanup measurements only
-  uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/cleanup@latest
   with:
     cleanup-reports: false
 ```
@@ -70,7 +70,7 @@ jobs:
 
 ```yaml
 - name: Cleanup measurements
-  uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/cleanup@latest
   with:
     git-perf-version: '0.17.2'
 ```
@@ -141,7 +141,7 @@ jobs:
           fetch-depth: 0  # Full checkout required for git perf operations
 
       - name: Cleanup old measurements and reports
-        uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+        uses: kaihowl/git-perf/.github/actions/cleanup@latest
         with:
           retention-days: 90
           backup: true
@@ -197,7 +197,7 @@ If you're using the report action with `reports-subdirectory`, ensure the cleanu
 
 ```yaml
 - name: Cleanup measurements and reports
-  uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/cleanup@latest
   with:
     retention-days: 90
     cleanup-reports: true
@@ -212,7 +212,7 @@ Test the cleanup before running it:
 
 ```yaml
 - name: Test cleanup (dry-run)
-  uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/cleanup@latest
   with:
     dry-run: true
     reports-subdirectory: 'perf'

--- a/.github/actions/report/README.md
+++ b/.github/actions/report/README.md
@@ -20,7 +20,7 @@ A GitHub Action to generate and publish git-perf performance reports to GitHub P
 ### Basic Usage
 
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -28,7 +28,7 @@ A GitHub Action to generate and publish git-perf performance reports to GitHub P
 ### Advanced Usage
 
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     depth: 100
     report-name: 'my-custom-report'
@@ -45,7 +45,7 @@ The action automatically comments on PRs by default. To disable automatic commen
 
 ```yaml
 - id: perf-report
-  uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     audit-args: '-m build_time -d 2.0 --min-measurements 5'
     comment-on-pr: 'false'  # Disable automatic PR commenting
@@ -186,7 +186,7 @@ jobs:
         with:
           fetch-depth: 40
 
-      - uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+      - uses: kaihowl/git-perf/.github/actions/report@latest
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -194,7 +194,7 @@ jobs:
 ### Generate Report with Audit
 
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     depth: 100
     audit-args: '-m build_time -m test_duration -d 2.5 --min-measurements 10'
@@ -204,7 +204,7 @@ jobs:
 ### Using Specific git-perf Version
 
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     git-perf-version: 'v1.2.3'
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -213,7 +213,7 @@ jobs:
 ### Disable PR Comments
 
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     comment-on-pr: 'false'
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -226,7 +226,7 @@ The action supports deploying reports to a subdirectory within GitHub Pages, all
 ### Deploy to Subdirectory
 
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     reports-subdirectory: 'perf'
     preserve-existing: 'true'
@@ -238,7 +238,7 @@ This deploys reports to `https://user.github.io/repo/perf/` instead of the root.
 ### Enable Epoch and Change Point Detection
 
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     show-epochs: 'true'
     show-changes: 'true'
@@ -261,7 +261,7 @@ The action supports multi-section dashboard templates for comprehensive performa
 
 2. Use the template in your workflow:
    ```yaml
-   - uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+   - uses: kaihowl/git-perf/.github/actions/report@latest
      with:
        template: '.git-perf/templates/performance-overview.html'
        github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -302,7 +302,7 @@ jobs:
         with:
           fetch-depth: 100
 
-      - uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+      - uses: kaihowl/git-perf/.github/actions/report@latest
         with:
           reports-subdirectory: 'perf'
           preserve-existing: 'true'

--- a/README.md
+++ b/README.md
@@ -824,7 +824,7 @@ This converts your shallow clone to a full clone, allowing all measurements to b
 Configure cleanup retention:
 ```yaml
 # In .github/workflows/cleanup-measurements.yml
-- uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/cleanup@latest
   with:
     retention-days: 90  # Days to retain measurements
 ```
@@ -875,7 +875,7 @@ Use the report action for automatic PR comments:
 
 ```yaml
 - name: Generate report with audit
-  uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     depth: 40
     audit-args: '-m build_time -m binary_size -d 4.0'

--- a/docs/INTEGRATION_TUTORIAL.md
+++ b/docs/INTEGRATION_TUTORIAL.md
@@ -157,7 +157,7 @@ jobs:
 
       # Install git-perf
       - name: Install git-perf
-        uses: kaihowl/git-perf/.github/actions/install@v0.16.0
+        uses: kaihowl/git-perf/.github/actions/install@latest
         with:
           release: latest
 
@@ -244,7 +244,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install git-perf
-        uses: kaihowl/git-perf/.github/actions/install@v0.16.0
+        uses: kaihowl/git-perf/.github/actions/install@latest
         with:
           release: latest
 
@@ -265,7 +265,7 @@ jobs:
         run: git perf push
 
       - name: Generate performance report
-        uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+        uses: kaihowl/git-perf/.github/actions/report@latest
         with:
           depth: 40
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -348,7 +348,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cleanup measurements and reports
-        uses: kaihowl/git-perf/.github/actions/cleanup@v0.16.0
+        uses: kaihowl/git-perf/.github/actions/cleanup@latest
         with:
           retention-days: 90
           cleanup-reports: true
@@ -400,7 +400,7 @@ Update your workflow to run audits and fail on regressions. You can also integra
 
 # Option 2: Integrate audit with report generation
 - name: Generate report with audit
-  uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+  uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     depth: 40
     audit-args: '-m build_time -m binary_size -d 4.0 --min-measurements 5'
@@ -850,7 +850,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: kaihowl/git-perf/.github/actions/install@v0.16.0
+      - uses: kaihowl/git-perf/.github/actions/install@latest
 
       - name: Build and measure
         run: |
@@ -866,7 +866,7 @@ jobs:
         run: git perf push
 
       - name: Generate report with audit
-        uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+        uses: kaihowl/git-perf/.github/actions/report@latest
         with:
           depth: 40
           audit-args: '-m build_time -m binary_size -m test_duration -d 4.0 --min-measurements 5'

--- a/docs/plans/github-pages-integration-and-templating.md
+++ b/docs/plans/github-pages-integration-and-templating.md
@@ -904,7 +904,7 @@ jobs:
         with:
           fetch-depth: 100
 
-      - uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+      - uses: kaihowl/git-perf/.github/actions/report@latest
         with:
           reports-subdirectory: 'perf'
           preserve-existing: 'true'
@@ -1164,7 +1164,7 @@ This index is preserved by `keep_files: true` when reports are deployed to `/per
 
 **Current Setup:**
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -1173,7 +1173,7 @@ This index is preserved by `keep_files: true` when reports are deployed to `/per
 
 **Optional Migration to Subdirectory:**
 ```yaml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     reports-subdirectory: 'perf'
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -1209,7 +1209,7 @@ concurrency:
 **Step 3**: Add performance workflow:
 ```yaml
 # .github/workflows/performance.yml
-- uses: kaihowl/git-perf/.github/actions/report@v0.16.0
+- uses: kaihowl/git-perf/.github/actions/report@latest
   with:
     reports-subdirectory: 'perf'
     preserve-existing: 'true'


### PR DESCRIPTION
## Summary
- Updated all GitHub Action references from `@master` to `@latest` in documentation and examples.

## Changes
- Documentation updates to reference `@latest` for all GitHub Actions:
  - .github/actions/cleanup/README.md
  - .github/actions/report/README.md
  - README.md
  - docs/INTEGRATION_TUTORIAL.md
  - docs/plans/github-pages-integration-and-templating.md
- No code changes; only documentation updates to align with release tagging.

## Rationale
- Ensures docs consistently point to the latest released version tag instead of master for user workflows and examples.
- Using `@latest` provides a more stable reference that automatically follows new releases.

## Testing plan
- Verify no remaining `@master` references:
  - Run a repository-wide search for "@master" (expect zero results).
- Confirm the documentation accurately reflects the recommended usage pattern.
- Do a quick skim of the updated sections in README and docs to ensure syntax and references are correct.