### PR TITLE
feat(reporting): add commit author and title to change point hover text

### DIFF
--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -675,11 +675,10 @@ impl PlotlyReporter {
                 ChangeDirection::Decrease => (IMPROVEMENT_COLOR, "✓ Improvement"),
             };
 
-            // Look up commit metadata (author and title) from all_commits
+            // Look up commit metadata (author and title) from all_commits using the changepoint index
             let (author, title) = self
                 .all_commits
-                .iter()
-                .find(|c| c.commit == cp.commit_sha)
+                .get(cp.index)
                 .map(|c| (c.author.as_str(), c.title.as_str()))
                 .unwrap_or(("Unknown", "Unknown"));
 


### PR DESCRIPTION
## Summary
- Add PR 578 commit author and title to hover tooltips for performance plots
- Hover now displays Author and Title along with percentage, short SHA, and confidence

## Changes

### Hover text enhancement
- Look up author and title for each commit by matching the commit SHA against all_commits
- Extend hover_text to include Author and Title fields
- Default to "Unknown" if metadata is not found

### Tests
- Update tests to verify author and title appear in the hover HTML
- New assertions check for the author string (e.g., "Test Author") and the commit title (e.g., "test: commit 2")

## Test plan
- Run cargo test to ensure tests pass
- Verify hover tooltips contain author and title text in test HTML, alongside existing checks for percentage and short SHA


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/700632de-fd39-4bac-9906-def8e67bb05a