### PR TITLE
fix(test): update slow test loop to use new glob_test test names

### DIFF
--- a/test/run_test_loop.sh
+++ b/test/run_test_loop.sh
@@ -14,8 +14,9 @@ while [ $iteration -le $max_iterations ]; do
     echo "Running slow bash tests..."
     echo "=========================="
     
-    # Run the test using cargo nextest
-    if cargo nextest run run_slow_bash_tests_with_binary --lib --test bash_tests; then
+    # Run the slow test using cargo nextest
+    # With glob_test, the test name is based on the file path
+    if cargo nextest run testslow --test bash_tests; then
         echo "✅ Test passed on iteration $iteration"
         echo "Continuing to next iteration..."
         ((iteration++))


### PR DESCRIPTION
## Summary

Fix the slow test loop CI job which was failing due to outdated test names after the bash test framework migration.

## Context

The bash tests were recently migrated from rstest to glob_test in commit 3d33b72 (#554). This changed how test names are generated:
- **Old**: Single test named `run_slow_bash_tests_with_binary` 
- **New**: Individual tests named based on file paths (e.g., `testslow_concurrency_push_add`)

## Changes

Updated `test/run_test_loop.sh` to use the new test name pattern `testslow` which matches the slow test file `testslow_concurrency_push_add.sh`.

## Related Issues

Fixes https://github.com/kaihowl/git-perf/actions/runs/20671002260/job/59351662695

## Testing

The fix updates the slow test loop to correctly target the slow bash test using the new glob_test-based naming convention. The test should now run successfully instead of reporting "no tests to run".

🤖 Generated with [Claude Code](https://claude.com/claude-code)