### PR TITLE
ci: reduce slow-test-loop timeout to 2 hours

### DIFF
--- a/.github/workflows/slow-test-loop.yml
+++ b/.github/workflows/slow-test-loop.yml
@@ -21,7 +21,7 @@ jobs:
   slow-test-loop:
     name: Slow Test Loop (until failure)
     runs-on: ubuntu-22.04
-    timeout-minutes: 360  # 6 hours maximum runtime
+    timeout-minutes: 120  # 2 hours maximum runtime
     
     env:
       # Emit backtraces on panics


### PR DESCRIPTION
## Summary
- Reduces the timeout for the Slow Test Loop workflow from 6 hours to 2 hours to shorten CI feedback and limit resource usage.
- Keeps existing steps and logic intact.

## Changes

### CI/CD Configuration
- **slow-test-loop workflow**: Updated .github/workflows/slow-test-loop.yml timeout-minutes from 360 to 120.
- Updated inline comment accordingly: 2 hours maximum runtime.

### Rationale
- errors that are not found after two hours are also likely to be found after two six hours. 

## Test plan
- [x] Verify timeout-minutes is set to 120 in the workflow file
- [x] Trigger a run to confirm the workflow ends at or before the 2-hour mark (or times out if still running)
- [x] Ensure no YAML syntax errors and that other steps execute as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/891cb7e6-1a48-4abf-8f05-a1750066288a