### PR TITLE
feat(git_perf): add --since/--until date filtering to audit and report

### DIFF
--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -106,6 +106,18 @@ pub struct CliReportHistory {
     /// HEAD is included in this count.
     #[arg(short = 'n', long, default_value = "40")]
     pub max_count: usize,
+
+    /// Only include commits more recent than a specific date.
+    /// Accepts all formats that `git log --since` accepts, e.g.
+    /// "2025-01-01", "2 weeks ago", "yesterday".
+    #[arg(long, alias = "after")]
+    pub since: Option<String>,
+
+    /// Only include commits older than a specific date.
+    /// Accepts all formats that `git log --until` accepts, e.g.
+    /// "2025-12-31", "yesterday".
+    #[arg(long, alias = "before")]
+    pub until: Option<String>,
 }
 
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -181,6 +181,8 @@ Create an HTML performance report
 * `-n`, `--max-count <MAX_COUNT>` — Limit the number of previous commits considered. HEAD is included in this count
 
   Default value: `40`
+* `--since <SINCE>` — Only include commits more recent than a specific date. Accepts all formats that `git log --since` accepts, e.g. "2025-01-01", "2 weeks ago", "yesterday"
+* `--until <UNTIL>` — Only include commits older than a specific date. Accepts all formats that `git log --until` accepts, e.g. "2025-12-31", "yesterday"
 * `-m`, `--measurement <MEASUREMENT>` — Select an individual measurements instead of all
 * `-k`, `--key-value <KEY_VALUE>` — Key-value pairs separated by '=', select only matching measurements
 * `-f`, `--filter <FILTER>` — Filter measurements by regex pattern (can be specified multiple times). If any filter matches, the measurement is included (OR logic). Patterns are unanchored by default. Use ^pattern$ for exact matches. Example: -f "bench.*" -f "test_.*"
@@ -243,6 +245,8 @@ The sparkline visualization shows the range of measurements relative to the tail
 * `-n`, `--max-count <MAX_COUNT>` — Limit the number of previous commits considered. HEAD is included in this count
 
   Default value: `40`
+* `--since <SINCE>` — Only include commits more recent than a specific date. Accepts all formats that `git log --since` accepts, e.g. "2025-01-01", "2 weeks ago", "yesterday"
+* `--until <UNTIL>` — Only include commits older than a specific date. Accepts all formats that `git log --until` accepts, e.g. "2025-12-31", "yesterday"
 * `-s`, `--selectors <SELECTORS>` — Key-value pair separated by "=" with no whitespaces to subselect measurements
 * `-f`, `--filter <FILTER>` — Filter measurements by regex pattern (can be specified multiple times). At least one of --measurement or --filter must be provided. If any filter matches, the measurement is included (OR logic). Patterns are unanchored by default. Use ^pattern$ for exact matches. Examples: -f "bench_.*" (prefix), -f ".*_x64$" (suffix), -f "^perf_" (anchored prefix)
 * `-S`, `--separate-by <SEPARATE_BY>` — Create separate audit groups by grouping with the value of this selector. Can be specified multiple times to split on multiple dimensions (e.g., -S os -S arch). Multiple splits create combined group labels like "os=ubuntu/arch=x64". Each group is audited independently with its own statistical validation

--- a/git_perf/src/audit.rs
+++ b/git_perf/src/audit.rs
@@ -195,6 +195,8 @@ fn format_group_label(separate_by: &[String], group_values: &[String]) -> String
 pub fn audit_multiple(
     start_commit: &str,
     max_count: usize,
+    since: Option<&str>,
+    until: Option<&str>,
     min_count: Option<u16>,
     selectors: &[(String, String)],
     summarize_by: Option<ReductionFunc>,
@@ -228,7 +230,7 @@ pub fn audit_multiple(
     // Phase 1: Walk commits ONCE (optimization: scan commits only once)
     // Collect into Vec so we can reuse the data for multiple measurements
     let all_commits: Vec<Result<Commit>> =
-        measurement_retrieval::walk_commits_from(start_commit, max_count)?.collect();
+        measurement_retrieval::walk_commits_from(start_commit, max_count, since, until)?.collect();
 
     // Phase 2: Discover all measurements that match the combined patterns from the commit data
     // The combined_patterns already include both measurements (as exact regex) and filters (OR behavior)
@@ -739,6 +741,8 @@ mod test {
             let result = audit_multiple(
                 "HEAD",
                 100,
+                None,
+                None,
                 Some(1),
                 &[],
                 Some(ReductionFunc::Mean),

--- a/git_perf/src/cli.rs
+++ b/git_perf/src/cli.rs
@@ -111,6 +111,8 @@ pub fn handle_calls() -> Result<()> {
                 output,
                 separate_by,
                 report_history.max_count,
+                report_history.since.as_deref(),
+                report_history.until.as_deref(),
                 &key_value,
                 aggregate_by.map(ReductionFunc::from),
                 &combined_patterns,
@@ -158,6 +160,8 @@ pub fn handle_calls() -> Result<()> {
             audit::audit_multiple(
                 commit,
                 report_history.max_count,
+                report_history.since.as_deref(),
+                report_history.until.as_deref(),
                 min_measurements,
                 &selectors,
                 aggregate_by.map(ReductionFunc::from),

--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -949,7 +949,12 @@ fn update_pending_read_branch() -> Result<TempRef> {
 ///     println!("Commit: {} by {}: {}", commit.sha, commit.author, commit.title);
 /// }
 /// ```
-pub fn walk_commits_from(start_commit: &str, num_commits: usize) -> Result<Vec<CommitWithNotes>> {
+pub fn walk_commits_from(
+    start_commit: &str,
+    num_commits: usize,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<Vec<CommitWithNotes>> {
     // update local read branch
     let temp_ref = update_read_branch()?;
 
@@ -957,23 +962,33 @@ pub fn walk_commits_from(start_commit: &str, num_commits: usize) -> Result<Vec<C
     let resolved_commit = resolve_committish(start_commit)
         .context(format!("Failed to resolve commit '{}'", start_commit))?;
 
-    let output = capture_git_output(
-        &[
-            "--no-pager",
-            "log",
-            "--no-color",
-            "--ignore-missing",
-            "-n",
-            num_commits.to_string().as_str(),
-            "--first-parent",
-            "--pretty=--,%H,%s,%an,%D%n%N",
-            "--decorate=full",
-            format!("--notes={}", temp_ref.ref_name).as_str(),
-            &resolved_commit,
-        ],
-        &None,
-    )
-    .context(format!("Failed to retrieve commits from {}", start_commit))?;
+    let num_commits_str = num_commits.to_string();
+    let notes_ref = format!("--notes={}", temp_ref.ref_name);
+    let since_arg = since.map(|s| format!("--since={}", s));
+    let until_arg = until.map(|u| format!("--until={}", u));
+
+    let mut args = vec![
+        "--no-pager",
+        "log",
+        "--no-color",
+        "--ignore-missing",
+        "-n",
+        &num_commits_str,
+        "--first-parent",
+        "--pretty=--,%H,%s,%an,%D%n%N",
+        "--decorate=full",
+        &notes_ref,
+    ];
+    if let Some(ref s) = since_arg {
+        args.push(s.as_str());
+    }
+    if let Some(ref u) = until_arg {
+        args.push(u.as_str());
+    }
+    args.push(&resolved_commit);
+
+    let output = capture_git_output(&args, &None)
+        .context(format!("Failed to retrieve commits from {}", start_commit))?;
 
     let mut commits: Vec<CommitWithNotes> = Vec::new();
     let mut detected_shallow = false;
@@ -1028,7 +1043,7 @@ pub fn walk_commits_from(start_commit: &str, num_commits: usize) -> Result<Vec<C
 
 /// Walk commits starting from HEAD (convenience wrapper)
 pub fn walk_commits(num_commits: usize) -> Result<Vec<CommitWithNotes>> {
-    walk_commits_from("HEAD", num_commits)
+    walk_commits_from("HEAD", num_commits, None, None)
 }
 
 /// Get commits that have notes in a specific notes ref.

--- a/git_perf/src/measurement_retrieval.rs
+++ b/git_perf/src/measurement_retrieval.rs
@@ -107,7 +107,7 @@ where
 ///
 /// ```no_run
 /// # use git_perf::measurement_retrieval::walk_commits_from;
-/// for commit_result in walk_commits_from("HEAD", 10).unwrap() {
+/// for commit_result in walk_commits_from("HEAD", 10, None, None).unwrap() {
 ///     let commit = commit_result.unwrap();
 ///     println!("Commit: {}", commit.commit);
 /// }
@@ -115,8 +115,10 @@ where
 pub fn walk_commits_from(
     start_commit: &str,
     num_commits: usize,
+    since: Option<&str>,
+    until: Option<&str>,
 ) -> Result<impl Iterator<Item = Result<Commit>>> {
-    let vec = git_interop::walk_commits_from(start_commit, num_commits)?;
+    let vec = git_interop::walk_commits_from(start_commit, num_commits, since, until)?;
     Ok(vec
         .into_iter()
         .take(num_commits)
@@ -131,8 +133,4 @@ pub fn walk_commits_from(
             })
         }))
     // When this fails it is due to a shallow clone.
-}
-
-pub fn walk_commits(num_commits: usize) -> Result<impl Iterator<Item = Result<Commit>>> {
-    walk_commits_from("HEAD", num_commits)
 }

--- a/git_perf/src/reporting.rs
+++ b/git_perf/src/reporting.rs
@@ -1807,6 +1807,8 @@ pub fn report(
     output: PathBuf,
     separate_by: Vec<String>,
     num_commits: usize,
+    since: Option<&str>,
+    until: Option<&str>,
     key_values: &[(String, String)],
     aggregate_by: Option<ReductionFunc>,
     combined_patterns: &[String],
@@ -1819,7 +1821,8 @@ pub fn report(
     let _filters = crate::filter::compile_filters(combined_patterns)?;
 
     let commits: Vec<Commit> =
-        measurement_retrieval::walk_commits_from(start_commit, num_commits)?.try_collect()?;
+        measurement_retrieval::walk_commits_from(start_commit, num_commits, since, until)?
+            .try_collect()?;
 
     if commits.is_empty() {
         bail!(

--- a/man/man1/git-perf-audit.1
+++ b/man/man1/git-perf-audit.1
@@ -4,7 +4,7 @@
 .SH NAME
 audit \- For given measurements, check perfomance deviations of the HEAD commit against `<n>` previous commits. Group previous results and aggregate their results before comparison
 .SH SYNOPSIS
-\fBaudit\fR [\fB\-m\fR|\fB\-\-measurement\fR] [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-s\fR|\fB\-\-selectors\fR] [\fB\-f\fR|\fB\-\-filter\fR] [\fB\-S\fR|\fB\-\-separate\-by\fR] [\fB\-\-min\-measurements\fR] [\fB\-a\fR|\fB\-\-aggregate\-by\fR] [\fB\-d\fR|\fB\-\-sigma\fR] [\fB\-D\fR|\fB\-\-dispersion\-method\fR] [\fB\-\-no\-change\-point\-warning\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fICOMMIT\fR] 
+\fBaudit\fR [\fB\-m\fR|\fB\-\-measurement\fR] [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-\-since\fR] [\fB\-\-until\fR] [\fB\-s\fR|\fB\-\-selectors\fR] [\fB\-f\fR|\fB\-\-filter\fR] [\fB\-S\fR|\fB\-\-separate\-by\fR] [\fB\-\-min\-measurements\fR] [\fB\-a\fR|\fB\-\-aggregate\-by\fR] [\fB\-d\fR|\fB\-\-sigma\fR] [\fB\-D\fR|\fB\-\-dispersion\-method\fR] [\fB\-\-no\-change\-point\-warning\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fICOMMIT\fR] 
 .SH DESCRIPTION
 For given measurements, check perfomance deviations of the HEAD commit against `<n>` previous commits. Group previous results and aggregate their results before comparison.
 .PP
@@ -44,6 +44,12 @@ Specific measurement names to audit (can be specified multiple times). At least 
 .TP
 \fB\-n\fR, \fB\-\-max\-count\fR \fI<MAX_COUNT>\fR [default: 40]
 Limit the number of previous commits considered. HEAD is included in this count
+.TP
+\fB\-\-since\fR \fI<SINCE>\fR
+Only include commits more recent than a specific date. Accepts all formats that `git log \-\-since` accepts, e.g. "2025\-01\-01", "2 weeks ago", "yesterday"
+.TP
+\fB\-\-until\fR \fI<UNTIL>\fR
+Only include commits older than a specific date. Accepts all formats that `git log \-\-until` accepts, e.g. "2025\-12\-31", "yesterday"
 .TP
 \fB\-s\fR, \fB\-\-selectors\fR \fI<SELECTORS>\fR
 Key\-value pair separated by "=" with no whitespaces to subselect measurements

--- a/man/man1/git-perf-report.1
+++ b/man/man1/git-perf-report.1
@@ -4,7 +4,7 @@
 .SH NAME
 report \- Create an HTML performance report
 .SH SYNOPSIS
-\fBreport\fR [\fB\-o\fR|\fB\-\-output\fR] [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-m\fR|\fB\-\-measurement\fR] [\fB\-k\fR|\fB\-\-key\-value\fR] [\fB\-f\fR|\fB\-\-filter\fR] [\fB\-s\fR|\fB\-\-separate\-by\fR] [\fB\-a\fR|\fB\-\-aggregate\-by\fR] [\fB\-t\fR|\fB\-\-template\fR] [\fB\-c\fR|\fB\-\-custom\-css\fR] [\fB\-\-title\fR] [\fB\-\-show\-epochs\fR] [\fB\-\-show\-changes\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fICOMMIT\fR] 
+\fBreport\fR [\fB\-o\fR|\fB\-\-output\fR] [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-\-since\fR] [\fB\-\-until\fR] [\fB\-m\fR|\fB\-\-measurement\fR] [\fB\-k\fR|\fB\-\-key\-value\fR] [\fB\-f\fR|\fB\-\-filter\fR] [\fB\-s\fR|\fB\-\-separate\-by\fR] [\fB\-a\fR|\fB\-\-aggregate\-by\fR] [\fB\-t\fR|\fB\-\-template\fR] [\fB\-c\fR|\fB\-\-custom\-css\fR] [\fB\-\-title\fR] [\fB\-\-show\-epochs\fR] [\fB\-\-show\-changes\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fICOMMIT\fR] 
 .SH DESCRIPTION
 Create an HTML performance report
 .SH OPTIONS
@@ -14,6 +14,12 @@ HTML output file
 .TP
 \fB\-n\fR, \fB\-\-max\-count\fR \fI<MAX_COUNT>\fR [default: 40]
 Limit the number of previous commits considered. HEAD is included in this count
+.TP
+\fB\-\-since\fR \fI<SINCE>\fR
+Only include commits more recent than a specific date. Accepts all formats that `git log \-\-since` accepts, e.g. "2025\-01\-01", "2 weeks ago", "yesterday"
+.TP
+\fB\-\-until\fR \fI<UNTIL>\fR
+Only include commits older than a specific date. Accepts all formats that `git log \-\-until` accepts, e.g. "2025\-12\-31", "yesterday"
 .TP
 \fB\-m\fR, \fB\-\-measurement\fR \fI<MEASUREMENT>\fR
 Select an individual measurements instead of all

--- a/test/test_flexible_range.sh
+++ b/test/test_flexible_range.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+export TEST_TRACE=0
+
+script_dir=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
+# shellcheck source=test/common.sh
+source "$script_dir/common.sh"
+
+# ============================================================================
+# Setup: A repo with 4 commits, all created "today" (no faketime needed)
+# ============================================================================
+
+test_section "Setup: repo with multiple commits"
+
+cd_empty_repo
+
+# Create 4 commits with measurements
+create_commit; git perf add -m timer 10.0
+create_commit; git perf add -m timer 10.0
+create_commit; git perf add -m timer 10.0
+create_commit; git perf add -m timer 10.0
+
+# ============================================================================
+# --since with an old date: should include all recent commits
+# ============================================================================
+
+test_section "--since with old date includes all recent commits"
+
+# "1 year ago" should include all commits made today (4 data rows + 1 header = 5 lines)
+assert_success_with_output output git perf report --since="1 year ago" -o -
+lines=$(echo "$output" | wc -l | tr -d ' ')
+assert_equals "$lines" "5" "Expected all 4 measurements + header with --since=1 year ago"
+
+# ============================================================================
+# --until with a very old date: no commits before 2000, so error expected
+# ============================================================================
+
+test_section "--until with old date excludes all recent commits"
+
+assert_failure git perf report --until="2000-01-01" -o -
+
+# ============================================================================
+# --since + -n combined: -n still limits count within the time window
+# ============================================================================
+
+test_section "--since and -n can be combined"
+
+# --since="1 year ago" gives all 4 commits; -n 2 restricts to the 2 most recent
+assert_success_with_output output git perf report --since="1 year ago" -n 2 -o -
+lines=$(echo "$output" | wc -l | tr -d ' ')
+assert_equals "$lines" "3" "Expected 2 measurements + header with --since + -n 2"
+
+# ============================================================================
+# --until with today or future date: includes all commits
+# ============================================================================
+
+test_section "--until with future date includes all commits"
+
+# A future date should include all current commits (4 data rows + 1 header = 5 lines)
+assert_success_with_output output git perf report --until="2030-01-01" -o -
+lines=$(echo "$output" | wc -l | tr -d ' ')
+assert_equals "$lines" "5" "Expected all 4 measurements + header with --until=2030-01-01"
+
+# ============================================================================
+# --since for audit: all recent commits are within range
+# ============================================================================
+
+test_section "--since works for audit"
+
+# All 4 commits are within last year: HEAD + 3 historical → should pass
+assert_success git perf audit -m timer --since="1 year ago"
+
+# --since with old date + -n 2: only 2 commits (HEAD + 1 historical) → passes with default min-measurements=2
+assert_success git perf audit -m timer --since="1 year ago" -n 2
+
+# ============================================================================
+# --after alias works (same as --since)
+# ============================================================================
+
+test_section "--after alias is equivalent to --since"
+
+assert_success_with_output output git perf report --after="1 year ago" -o -
+lines=$(echo "$output" | wc -l | tr -d ' ')
+assert_equals "$lines" "5" "--after alias should behave identically to --since"
+
+# ============================================================================
+# --before alias works (same as --until)
+# ============================================================================
+
+test_section "--before with old date excludes all recent commits"
+
+assert_failure git perf report --before="2000-01-01" -o -
+
+# ============================================================================
+# --until for audit: all commits before a future date
+# ============================================================================
+
+test_section "--until works for audit"
+
+assert_success git perf audit -m timer --until="2030-01-01"
+
+popd
+
+test_stats
+exit 0


### PR DESCRIPTION
Extend CliReportHistory with optional --since (alias --after) and
--until (alias --before) flags that are passed directly to git log,
allowing date-based filtering of commit history for both the audit and
report commands. For example:

  git perf audit -m timer --since="2 weeks ago"
  git perf report --since="2025-01-01" --until="2025-06-30" -o out.html

Also removes the dead measurement_retrieval::walk_commits convenience
wrapper that was never called from production code.

https://claude.ai/code/session_01LMLsirJvMUcnsBpJAgQuGp