### PR TITLE
fix(git_perf): resolve clippy warning from Rust 1.95.0 toolchain bump

### DIFF
--- a/git_perf/src/size.rs
+++ b/git_perf/src/size.rs
@@ -96,7 +96,7 @@ fn display_size_report(
 
         // Sort by size descending
         let mut sorted: Vec<_> = by_name.iter().collect();
-        sorted.sort_by(|a, b| b.1.total_bytes.cmp(&a.1.total_bytes));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.total_bytes));
 
         for (name, size_info) in sorted {
             println!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Pin Rust version to prevent unexpected CI breakages from new compiler releases
 # Dependabot will automatically create PRs to update this version
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Replace sort_by with sort_by_key to satisfy the unnecessary_sort_by lint
introduced in the 1.95.0 clippy, and update the pinned toolchain version.

https://claude.ai/code/session_01Aj8RVqfKZa4x2EE6FRjhAL