### PR TITLE
ci: add Rust cache and --locked to report job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,12 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Install git-perf from branch
         run: |
-          cargo install --path git_perf
+          cargo install --locked --path git_perf
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - uses: ./.github/actions/report

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -6,6 +6,7 @@ jobs:
   test_with_git_versions:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # Test against multiple git versions to ensure compatibility
         # NOTE: All versions must be >= 2.43.0 (see git_definitions.rs:EXPECTED_VERSION)

--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -1004,7 +1004,7 @@ fn update_pending_read_branch() -> Result<TempRef> {
 ///
 /// ```no_run
 /// # use git_perf::git::git_interop::walk_commits_from;
-/// let commits = walk_commits_from("HEAD", 5).unwrap();
+/// let commits = walk_commits_from("HEAD", 5, None, None).unwrap();
 /// for commit in commits {
 ///     println!("Commit: {} by {}: {}", commit.sha, commit.author, commit.title);
 /// }

--- a/git_perf/src/git/git_lowlevel.rs
+++ b/git_perf/src/git/git_lowlevel.rs
@@ -191,7 +191,7 @@ pub(super) fn git_rev_parse(reference: &str) -> Result<String, GitError> {
 /// # Examples
 ///
 /// ```no_run
-/// # use git_perf::git::git_lowlevel::resolve_committish;
+/// # use git_perf::git::git_interop::resolve_committish;
 /// let sha = resolve_committish("HEAD").unwrap();
 /// assert_eq!(sha.len(), 40); // Full SHA-1 hash
 /// ```


### PR DESCRIPTION
The report job ("git-perf" check) was the only CI job without
Swatinem/rust-cache@v2, forcing a full recompile of all dependencies
on every run. Since it needs: [test, ...], the test (stable) job's
cache (same OS/toolchain/workspace) is already warm by the time this
job starts, so adding the cache step makes cargo install fast.

Also add --locked to cargo install to use the pinned Cargo.lock
versions, matching the --locked flag used by the release-binary-size
job.

https://claude.ai/code/session_01XjWT4QKWxNj6QsgwhMeUYe