### PR TITLE
fix(git): re-enable --no-separator for git notes append

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -170,6 +170,7 @@ fn raw_add_note_line(commit: &str, line: &str) -> Result<(), GitError> {
             "--ref",
             &temp_target,
             "append",
+            "--no-separator",
             "-m",
             line,
             &resolved_commit,


### PR DESCRIPTION

## Summary

- Re-adds `--no-separator` to the `git notes append` call in `raw_add_note_line`
- Closes #96

## Background

`--no-separator` was disabled in #97 (Jan 2024) because it was not available in the git versions supported at the time. The minimum required git version has since been raised to 2.43.0, while `--no-separator` has been available since git 2.39.0 — so it is now safe to enable unconditionally.

Without the flag, `git notes append` inserts a blank line between each appended note entry. The `deserialize` function already filtered these empty lines, so correctness was never affected, but the notes contained unnecessary whitespace. With the flag, notes are compact and contain no separator lines.

## Test plan

- [x] `cargo fmt` — no changes
- [x] `cargo clippy` — clean
- [x] `cargo nextest run -- --skip slow --skip test_remove` — 360/360 passed (`test_remove` requires `libfaketime`, pre-existing skip)
- [x] Mutation testing: 1 mutant found, 1 caught (exit 0)

https://claude.ai/code/session_01DtkUkKjwP4tm1QHEQff3zV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtkUkKjwP4tm1QHEQff3zV)_