### PR TITLE
fix(git): eliminate panic, make notes-append lockable, fix wait-status capture

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,5 +1,5 @@
 test_tool = "nextest"
 exclude_globs = ["examples/**", "benches/**", "git_perf/tests/**", "git_perf/src/main.rs", "git_perf/src/cli.rs", "git_perf/src/test_helpers.rs"]
-additional_cargo_test_args = ["--fail-fast", "--", "--skip", "slow", "--skip", "test_remove"]
+additional_cargo_test_args = ["--", "--skip", "slow", "--skip", "test_remove"]
 timeout_multiplier = 2.0
 minimum_test_timeout = 60

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,5 +1,5 @@
 test_tool = "nextest"
 exclude_globs = ["examples/**", "benches/**", "git_perf/tests/**", "git_perf/src/main.rs", "git_perf/src/cli.rs", "git_perf/src/test_helpers.rs"]
-additional_cargo_test_args = ["--", "--skip", "slow", "--skip", "test_remove"]
+additional_cargo_test_args = ["--fail-fast", "--", "--skip", "slow", "--skip", "test_remove"]
 timeout_multiplier = 2.0
 minimum_test_timeout = 60

--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -1668,4 +1668,20 @@ mod test {
             "PID {pid} should be dead after process exited",
         );
     }
+
+    /// Test that raw_add_note_line succeeds under normal conditions (symref present).
+    /// This directly exercises the ok_or_else path without the 60-second backoff
+    /// wrapper, so any mutant that makes the function always return an error is
+    /// caught immediately rather than after a full backoff cycle.
+    #[test]
+    fn test_raw_add_note_line_succeeds_in_normal_repo() {
+        with_isolated_cwd_git(|_git_dir| {
+            let result = raw_add_note_line("HEAD", "test_measurement=1.0");
+            assert!(
+                result.is_ok(),
+                "raw_add_note_line should succeed in a freshly initialised repo: {:?}",
+                result
+            );
+        });
+    }
 }

--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -154,7 +154,14 @@ fn raw_add_note_line(commit: &str, line: &str) -> Result<(), GitError> {
     let current_note_head =
         git_rev_parse(REFS_NOTES_WRITE_SYMBOLIC_REF).unwrap_or(EMPTY_OID.to_string());
     let current_symbolic_ref_target = git_rev_parse_symbolic_ref(REFS_NOTES_WRITE_SYMBOLIC_REF)
-        .expect("Missing symbolic-ref for target");
+        .ok_or_else(|| GitError::RefFailedToLock {
+            output: GitOutput {
+                stdout: String::new(),
+                stderr: format!(
+                    "symbolic-ref {REFS_NOTES_WRITE_SYMBOLIC_REF} vanished after creation"
+                ),
+            },
+        })?;
     let temp_target = create_temp_add_head(&current_note_head)?;
 
     defer!(if let Err(e) = remove_reference(&temp_target) {
@@ -176,7 +183,8 @@ fn raw_add_note_line(commit: &str, line: &str) -> Result<(), GitError> {
             &resolved_commit,
         ],
         &None,
-    )?;
+    )
+    .map_err(map_git_error)?;
 
     // Update current write branch with pending write
     // We update the target ref directly (no symref-verify needed in git 2.43.0)

--- a/git_perf/src/git/git_lowlevel.rs
+++ b/git_perf/src/git/git_lowlevel.rs
@@ -100,6 +100,9 @@ pub(super) fn map_git_error(err: GitError) -> GitError {
         GitError::ExecError { output, .. } if output.stderr.contains("cannot lock ref") => {
             GitError::RefFailedToLock { output }
         }
+        GitError::ExecError { output, .. } if output.stderr.contains("unable to lock ref") => {
+            GitError::RefFailedToLock { output }
+        }
         GitError::ExecError { output, .. } if output.stderr.contains("but expected") => {
             GitError::RefConcurrentModification { output }
         }
@@ -512,6 +515,21 @@ mod test {
         let output = GitOutput {
             stdout: String::new(),
             stderr: "error: packed-refs.lock is held by another process".to_string(),
+        };
+        let error = GitError::ExecError {
+            command: "update-ref".to_string(),
+            output,
+        };
+        let mapped = map_git_error(error);
+        assert!(matches!(mapped, GitError::RefFailedToLock { .. }));
+    }
+
+    #[test]
+    fn test_map_git_error_unable_to_lock_ref_maps_to_ref_failed_to_lock() {
+        let output = GitOutput {
+            stdout: String::new(),
+            stderr: "fatal: unable to lock ref 'refs/notes/perf-v3': reference already exists"
+                .to_string(),
         };
         let error = GitError::ExecError {
             command: "update-ref".to_string(),

--- a/test/testslow_concurrency_push_add.sh
+++ b/test/testslow_concurrency_push_add.sh
@@ -202,28 +202,24 @@ echo "Waiting for all tests to complete..."
 set +e
 
 PUSH_STATUS=0
-if [ $CONCURRENT_PUSHERS -gt 0 ]; then
-  wait "${PUSH_PIDS[@]}"
-  PUSH_STATUS=$?
-fi
+for pid in "${PUSH_PIDS[@]}"; do
+  wait "$pid" || PUSH_STATUS=$?
+done
 
 REMOVE_STATUS=0
-if [ $CONCURRENT_REMOVERS -gt 0 ]; then
-  wait "${REMOVE_PIDS[@]}"
-  REMOVE_STATUS=$?
-fi
+for pid in "${REMOVE_PIDS[@]}"; do
+  wait "$pid" || REMOVE_STATUS=$?
+done
 
 ADD_STATUS=0
-if [ $CONCURRENT_ADDERS -gt 0 ]; then
-  wait "${ADD_PIDS[@]}"
-  ADD_STATUS=$?
-fi
+for pid in "${ADD_PIDS[@]}"; do
+  wait "$pid" || ADD_STATUS=$?
+done
 
 PRUNE_STATUS=0
-if [ $CONCURRENT_PRUNERS -gt 0 ]; then
-  wait "${PRUNE_PIDS[@]}"
-  PRUNE_STATUS=$?
-fi
+for pid in "${PRUNE_PIDS[@]}"; do
+  wait "$pid" || PRUNE_STATUS=$?
+done
 
 # Reset trap for normal completion
 trap - SIGINT SIGTERM


### PR DESCRIPTION
## Summary

Fixes the intermittent slow-test failure reported in #698. Four concurrency fixes:

- **Eliminate panic in `raw_add_note_line`**: The `expect("Missing symbolic-ref for target")` call would crash the entire adder process under heavy concurrent load, losing all subsequent measurements from that background job. Now returns `GitError::RefFailedToLock` (transient) so the operation retries via exponential backoff.

- **Make `git notes append` errors retryable**: The `capture_git_output` call for `git notes append` was not passing through `map_git_error`, so any lock-contention error ("cannot lock ref", "packed-refs.lock") was classified as a permanent `ExecError` and not retried. Added `.map_err(map_git_error)`.

- **Add "unable to lock ref" to `map_git_error`**: Git emits this string on some lock-failure code paths that differ from the already-handled "cannot lock ref". Without this pattern, those errors are treated as permanent.

- **Fix bash test `wait` status capture**: `wait "${PIDS[@]}"` returns the exit status of the *last* PID only, silently masking failures from earlier processes in each group. Replaced with an explicit per-PID loop so every non-zero status is captured.

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo nextest run -- --skip slow --skip test_remove` — 393/393 pass
- [x] `cargo mutants --test-tool=nextest --in-diff <diff>` — 3 caught, 1 unviable, 0 missed

https://claude.ai/code/session_01LMGr7pfaYzxYs6QqAG4wej

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMGr7pfaYzxYs6QqAG4wej)_