### PR TITLE
perf(ci): replace subprocess add-benchmark with in-process Criterion benchmark

### DIFF
--- a/.git-perf/templates/dashboard-example.html
+++ b/.git-perf/templates/dashboard-example.html
@@ -123,7 +123,7 @@
             <h2>⚡ Criterion Add Benchmark</h2>
             <p>In-process Criterion benchmark of add_note_line_to_head() for input size 1, with change point detection.</p>
             {{SECTION[criterion-add-benchmark]
-                measurement-filter: ^bench::add_measurements/add_measurement/1::mean$
+                measurement-filter: ^bench::add_measurements/add_measurement/1::median$
                 aggregate-by: median
                 show-epochs: true
                 show-changes: true

--- a/.git-perf/templates/dashboard-example.html
+++ b/.git-perf/templates/dashboard-example.html
@@ -106,7 +106,7 @@
     </header>
 
     <main>
-        <!-- Section 1: Add Benchmark -->
+        <!-- Section 1: Add Benchmark (legacy subprocess) -->
         <section class="report-section">
             <h2>🚀 Add Benchmark Performance</h2>
             <p>Median performance for add operations with change point detection and epoch boundaries.</p>
@@ -118,7 +118,19 @@
             }}
         </section>
 
-        <!-- Section 2: Report Benchmark -->
+        <!-- Section 2: Criterion Add Benchmark -->
+        <section class="report-section">
+            <h2>⚡ Criterion Add Benchmark</h2>
+            <p>In-process Criterion benchmark of add_note_line_to_head() for input size 1, with change point detection.</p>
+            {{SECTION[criterion-add-benchmark]
+                measurement-filter: ^bench::add_measurements/add_measurement/1::mean$
+                aggregate-by: median
+                show-epochs: true
+                show-changes: true
+            }}
+        </section>
+
+        <!-- Section 3: Report Benchmark -->
         <section class="report-section">
             <h2>📊 Report Benchmark Performance</h2>
             <p>Median performance for report generation with change point detection and epoch boundaries.</p>
@@ -130,7 +142,7 @@
             }}
         </section>
 
-        <!-- Section 3: Report Generation Performance -->
+        <!-- Section 4: Report Generation Performance -->
         <section class="report-section">
             <h2>⚙️ Report Generation Time</h2>
             <p>Report generation performance showing execution duration.</p>
@@ -142,7 +154,7 @@
             }}
         </section>
 
-        <!-- Section 4: Release Binary Size -->
+        <!-- Section 5: Release Binary Size -->
         <section class="report-section">
             <h2>💾 Release Binary Size</h2>
             <p>Binary size tracking with change point detection and epoch boundaries.</p>
@@ -154,7 +166,7 @@
             }}
         </section>
 
-        <!-- Section 5: Report Size -->
+        <!-- Section 6: Report Size -->
         <section class="report-section">
             <h2>📄 Report Size</h2>
             <p>Generated report size tracking with change point detection and epoch boundaries.</p>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
       run: |
           set -x
-          cargo criterion --bench add --message-format json > add-bench-results.json || true
+          cargo criterion --bench add --features test-helpers --message-format json > add-bench-results.json || true
 
           if [ -s add-bench-results.json ]; then
             cargo run -- import criterion-json add-bench-results.json \
@@ -314,7 +314,7 @@ jobs:
         with:
           depth: 40
           additional-args: '-s rust'
-          audit-args: '-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m release-binary-size --separate-by os --separate-by rust'
+          audit-args: '-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m bench::add_measurements/add_measurement/1::mean -m release-binary-size --separate-by os --separate-by rust'
           git-perf-version: 'skip'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           show-size: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,22 +115,18 @@ jobs:
           set -x
           cargo criterion --bench add --features test-helpers --message-format json > add-bench-results.json
 
-          if [ -s add-bench-results.json ]; then
-            cargo run -- import criterion-json add-bench-results.json \
-              --metadata ci=true \
-              --metadata os=${{matrix.os}} \
-              --metadata rust=${{matrix.rust}}
+          cargo run -- import criterion-json add-bench-results.json \
+            --metadata ci=true \
+            --metadata os=${{matrix.os}} \
+            --metadata rust=${{matrix.rust}}
 
-            cargo run -- push || true
+          cargo run -- push || true
 
-            cargo run -- audit -n 40 \
-              -m "bench::add_measurements/add_measurement/1::median" \
-              -s os=${{matrix.os}} -s rust=${{matrix.rust}} \
-              --min-measurements 3 \
-              || echo "add benchmark audit failed (expected on first runs)"
-          else
-            echo "No add benchmark results to import"
-          fi
+          cargo run -- audit -n 40 \
+            -m "bench::add_measurements/add_measurement/1::median" \
+            -s os=${{matrix.os}} -s rust=${{matrix.rust}} \
+            --min-measurements 3 \
+            || echo "add benchmark audit failed (expected on first runs)"
 
     - name: Run sample perf measurements
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
       run: |
           set -x
-          cargo criterion --bench add --features test-helpers --message-format json > add-bench-results.json || true
+          cargo criterion --bench add --features test-helpers --message-format json > add-bench-results.json
 
           if [ -s add-bench-results.json ]; then
             cargo run -- import criterion-json add-bench-results.json \
@@ -124,7 +124,7 @@ jobs:
             cargo run -- push || true
 
             cargo run -- audit -n 40 \
-              -m "bench::add_measurements/add_measurement/1::mean" \
+              -m "bench::add_measurements/add_measurement/1::median" \
               -s os=${{matrix.os}} -s rust=${{matrix.rust}} \
               --min-measurements 3 \
               || echo "add benchmark audit failed (expected on first runs)"
@@ -199,7 +199,7 @@ jobs:
           git perf push
 
           # Blocking audits: these must pass or CI fails
-          git perf audit -n 40 -m test-measure2 -m report-benchmark -m report-size-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}}
+          git perf audit -n 40 -m test-measure2 -m report-benchmark -m report-size-benchmark -m "bench::add_measurements/add_measurement/1::median" -s os=${{matrix.os}} -s rust=${{matrix.rust}}
 
           # Informational audits: failures don't block CI
           git perf audit -n 40 -m add-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "add-benchmark audit failed (informational only — replaced by Criterion benchmark)"
@@ -314,7 +314,7 @@ jobs:
         with:
           depth: 40
           additional-args: '-s rust'
-          audit-args: '-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m bench::add_measurements/add_measurement/1::mean -m release-binary-size --separate-by os --separate-by rust'
+          audit-args: '-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m bench::add_measurements/add_measurement/1::median -m release-binary-size --separate-by os --separate-by rust'
           git-perf-version: 'skip'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           show-size: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,33 @@ jobs:
             echo "No benchmark results to import"
           fi
 
+    - name: Run add benchmark and track performance
+      env:
+        GIT_AUTHOR_NAME: github-actions[bot]
+        GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        GIT_COMMITTER_NAME: github-actions[bot]
+        GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+      run: |
+          set -x
+          cargo criterion --bench add --message-format json > add-bench-results.json || true
+
+          if [ -s add-bench-results.json ]; then
+            cargo run -- import criterion-json add-bench-results.json \
+              --metadata ci=true \
+              --metadata os=${{matrix.os}} \
+              --metadata rust=${{matrix.rust}}
+
+            git push origin refs/notes/perf-v3 || true
+
+            cargo run -- audit -n 40 \
+              -m "bench::add_measurements/add_measurement/1::mean" \
+              -s os=${{matrix.os}} -s rust=${{matrix.rust}} \
+              --min-measurements 3 \
+              || echo "add benchmark audit failed (expected on first runs)"
+          else
+            echo "No add benchmark results to import"
+          fi
+
     - name: Run sample perf measurements
       env:
         GIT_AUTHOR_NAME: github-actions[bot]
@@ -172,9 +199,10 @@ jobs:
           git perf push
 
           # Blocking audits: these must pass or CI fails
-          git perf audit -n 40 -m test-measure2 -m report-benchmark -m add-benchmark -m report-size-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}}
+          git perf audit -n 40 -m test-measure2 -m report-benchmark -m report-size-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}}
 
           # Informational audits: failures don't block CI
+          git perf audit -n 40 -m add-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "add-benchmark audit failed (informational only — replaced by Criterion benchmark)"
           git perf audit -n 40 -m report -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "report audit failed (informational only)"
           git perf audit -n 40 -m report-size -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "report-size audit failed (informational only)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
               --metadata rust=${{matrix.rust}}
 
             # Push imported measurements
-            git push origin refs/notes/perf-v3 || true
+            cargo run -- push || true
 
             # Audit fibonacci benchmarks (using mean statistic)
             # Allow up to 10 sigma deviation to account for CI variability
@@ -121,7 +121,7 @@ jobs:
               --metadata os=${{matrix.os}} \
               --metadata rust=${{matrix.rust}}
 
-            git push origin refs/notes/perf-v3 || true
+            cargo run -- push || true
 
             cargo run -- audit -n 40 \
               -m "bench::add_measurements/add_measurement/1::mean" \

--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -27,7 +27,7 @@ sigma = 3
 aggregate_by = "min"
 min_measurements = 10
 
-[measurement."bench::add_measurements/add_measurement/1"]
+[measurement."bench::add_measurements/add_measurement/1::median"]
 unit = "ns"
 dispersion_method = "mad"
 sigma = 5.0

--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -27,6 +27,13 @@ sigma = 3
 aggregate_by = "min"
 min_measurements = 10
 
+[measurement."bench::add_measurements/add_measurement/1"]
+unit = "ns"
+dispersion_method = "mad"
+sigma = 5.0
+aggregate_by = "median"
+min_measurements = 3
+
 [measurement."add-benchmark"]
 epoch = "296bc41"
 unit = "ns"

--- a/git_perf/benches/add.rs
+++ b/git_perf/benches/add.rs
@@ -1,6 +1,6 @@
 use std::env::set_current_dir;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use git_perf::git::git_interop::add_note_line_to_head;
 use git_perf::test_helpers::{empty_commit, hermetic_git_env, init_repo_simple};
 use tempfile::tempdir;
@@ -19,19 +19,23 @@ fn prep_repo() -> tempfile::TempDir {
 }
 
 fn add_measurements(c: &mut Criterion) {
-    let _temp_dir = prep_repo();
-
     let mut group = c.benchmark_group("add_measurements");
+    group.sample_size(10);
     for num_measurements in [1, 50, 100].into_iter() {
+        group.throughput(Throughput::Elements(num_measurements as u64));
         group.bench_with_input(
             BenchmarkId::new("add_measurement", num_measurements),
             &num_measurements,
-            |b, i| {
-                b.iter(|| {
-                    for _ in 0..*i {
-                        add_note_line_to_head("some line measurement test").expect("Oh no");
-                    }
-                });
+            |b, &i| {
+                b.iter_batched(
+                    || prep_repo(),
+                    |_temp_dir| {
+                        for _ in 0..i {
+                            add_note_line_to_head("some line measurement test").expect("Oh no");
+                        }
+                    },
+                    BatchSize::PerIteration,
+                );
             },
         );
     }
@@ -40,24 +44,27 @@ fn add_measurements(c: &mut Criterion) {
 }
 
 fn add_multiple_measurements(c: &mut Criterion) {
-    let _temp_dir = prep_repo();
-
     let mut group = c.benchmark_group("add_multiple_measurements");
+    group.sample_size(10);
     for num_measurements in [1, 50, 100].into_iter() {
         let lines = ["some line measurement test"]
             .repeat(num_measurements)
             .join("\n");
+        group.throughput(Throughput::Elements(num_measurements as u64));
         group.bench_with_input(
             BenchmarkId::new("add_multiple_measurements", num_measurements),
             &num_measurements,
             |b, _i| {
-                b.iter(|| {
-                    add_note_line_to_head(&lines).expect("failed to add lines");
-                });
+                b.iter_batched(
+                    || prep_repo(),
+                    |_temp_dir| {
+                        add_note_line_to_head(&lines).expect("failed to add lines");
+                    },
+                    BatchSize::PerIteration,
+                );
             },
         );
     }
-
     group.finish();
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause of high variability**: The old `add-benchmark` measured `git perf add` via shell (`git perf measure -n 50 -- git perf add ...`), spawning ~9 git subprocesses per sample. Process fork/exec jitter on shared CI runners dominated the signal, causing a ~228µs MAD that required a `min_relative_deviation = 10.0` band-aid — making regressions under 10% invisible.
- **New approach**: In-process Criterion benchmark of `add_note_line_to_head()` tracked via `cargo criterion --bench add --message-format json` + `import criterion-json`, following the same pattern as the fibonacci benchmark.
- **Benchmark fix**: `add.rs` now uses `iter_batched(|| prep_repo(), ..., BatchSize::PerIteration)` so each Criterion sample gets a fresh git repo, preventing notes accumulation bias (old `b.iter()` caused the same commit to accumulate thousands of notes across samples, making later samples systematically slower).
- **CI**: New blocking step runs the Criterion add benchmark; old subprocess-based `add-benchmark` demoted to informational-only.

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo nextest run -- --skip slow --skip test_remove` passes (test_remove requires libfaketime)
- [ ] CI runs the new `cargo criterion --bench add` step and imports results
- [ ] `bench::add_measurements/add_measurement/1::mean` appears in tracked metrics after CI run

https://claude.ai/code/session_01NmWwUrmcdgR8stvPFFjKqZ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmWwUrmcdgR8stvPFFjKqZ)_