### PR TITLE
ci: track add benchmark via Criterion, use git-perf push instead of direct git push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
               --metadata rust=${{matrix.rust}}
 
             # Push imported measurements
-            git push origin refs/notes/perf-v3 || true
+            cargo run -- push || true
 
             # Audit fibonacci benchmarks (using mean statistic)
             # Allow up to 10 sigma deviation to account for CI variability
@@ -103,6 +103,33 @@ jobs:
             cargo run -- audit -n 40 -m "bench::fibonacci_20::mean" -s os=${{matrix.os}} -s rust=${{matrix.rust}} --min-measurements 3 --sigma 10 || echo "Fibonacci 20 audit failed (expected on first runs)"
           else
             echo "No benchmark results to import"
+          fi
+
+    - name: Run add benchmark and track performance
+      env:
+        GIT_AUTHOR_NAME: github-actions[bot]
+        GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        GIT_COMMITTER_NAME: github-actions[bot]
+        GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+      run: |
+          set -x
+          cargo criterion --bench add --message-format json > add-bench-results.json || true
+
+          if [ -s add-bench-results.json ]; then
+            cargo run -- import criterion-json add-bench-results.json \
+              --metadata ci=true \
+              --metadata os=${{matrix.os}} \
+              --metadata rust=${{matrix.rust}}
+
+            cargo run -- push || true
+
+            cargo run -- audit -n 40 \
+              -m "bench::add_measurements/add_measurement/1::mean" \
+              -s os=${{matrix.os}} -s rust=${{matrix.rust}} \
+              --min-measurements 3 \
+              || echo "add benchmark audit failed (expected on first runs)"
+          else
+            echo "No add benchmark results to import"
           fi
 
     - name: Run sample perf measurements
@@ -172,9 +199,10 @@ jobs:
           git perf push
 
           # Blocking audits: these must pass or CI fails
-          git perf audit -n 40 -m test-measure2 -m report-benchmark -m add-benchmark -m report-size-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}}
+          git perf audit -n 40 -m test-measure2 -m report-benchmark -m report-size-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}}
 
           # Informational audits: failures don't block CI
+          git perf audit -n 40 -m add-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "add-benchmark audit failed (informational only — replaced by Criterion benchmark)"
           git perf audit -n 40 -m report -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "report audit failed (informational only)"
           git perf audit -n 40 -m report-size -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "report-size audit failed (informational only)"
 

--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -27,6 +27,13 @@ sigma = 3
 aggregate_by = "min"
 min_measurements = 10
 
+[measurement."bench::add_measurements/add_measurement/1"]
+unit = "ns"
+dispersion_method = "mad"
+sigma = 5.0
+aggregate_by = "median"
+min_measurements = 3
+
 [measurement."add-benchmark"]
 epoch = "296bc41"
 unit = "ns"

--- a/git_perf/benches/add.rs
+++ b/git_perf/benches/add.rs
@@ -1,6 +1,6 @@
 use std::env::set_current_dir;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use git_perf::git::git_interop::add_note_line_to_head;
 use git_perf::test_helpers::{empty_commit, hermetic_git_env, init_repo_simple};
 use tempfile::tempdir;
@@ -19,19 +19,23 @@ fn prep_repo() -> tempfile::TempDir {
 }
 
 fn add_measurements(c: &mut Criterion) {
-    let _temp_dir = prep_repo();
-
     let mut group = c.benchmark_group("add_measurements");
+    group.sample_size(10);
     for num_measurements in [1, 50, 100].into_iter() {
+        group.throughput(Throughput::Elements(num_measurements as u64));
         group.bench_with_input(
             BenchmarkId::new("add_measurement", num_measurements),
             &num_measurements,
-            |b, i| {
-                b.iter(|| {
-                    for _ in 0..*i {
-                        add_note_line_to_head("some line measurement test").expect("Oh no");
-                    }
-                });
+            |b, &i| {
+                b.iter_batched(
+                    || prep_repo(),
+                    |_temp_dir| {
+                        for _ in 0..i {
+                            add_note_line_to_head("some line measurement test").expect("Oh no");
+                        }
+                    },
+                    BatchSize::PerIteration,
+                );
             },
         );
     }
@@ -40,24 +44,27 @@ fn add_measurements(c: &mut Criterion) {
 }
 
 fn add_multiple_measurements(c: &mut Criterion) {
-    let _temp_dir = prep_repo();
-
     let mut group = c.benchmark_group("add_multiple_measurements");
+    group.sample_size(10);
     for num_measurements in [1, 50, 100].into_iter() {
         let lines = ["some line measurement test"]
             .repeat(num_measurements)
             .join("\n");
+        group.throughput(Throughput::Elements(num_measurements as u64));
         group.bench_with_input(
             BenchmarkId::new("add_multiple_measurements", num_measurements),
             &num_measurements,
             |b, _i| {
-                b.iter(|| {
-                    add_note_line_to_head(&lines).expect("failed to add lines");
-                });
+                b.iter_batched(
+                    || prep_repo(),
+                    |_temp_dir| {
+                        add_note_line_to_head(&lines).expect("failed to add lines");
+                    },
+                    BatchSize::PerIteration,
+                );
             },
         );
     }
-
     group.finish();
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Aligns the CI changes from #704 with the rest of the CI config by:

- Replacing `git push origin refs/notes/perf-v3 || true` with `cargo run -- push || true` in both the existing fibonacci benchmark step and the new add benchmark step — all perf data pushes now go through git-perf consistently
- Adding a new "Run add benchmark and track performance" CI step that runs `cargo criterion --bench add`, imports results via `git-perf import criterion-json`, and audits via `git-perf audit`
- Demoting the legacy `add-benchmark` measurement from blocking to informational (it is superseded by the Criterion-based benchmark)
- Adding `.gitperfconfig` entry for `bench::add_measurements/add_measurement/1` with appropriate thresholds
- Updating `git_perf/benches/add.rs` to use `iter_batched` with `PerIteration` setup so each benchmark iteration gets a fresh repo, and adds `Throughput` tracking

## Test plan

- [ ] CI passes on this branch
- [ ] No `git push origin refs/notes/perf-v3` calls remain in ci.yml
- [ ] New "Run add benchmark" step runs and imports/pushes via `cargo run --`
- [ ] Blocking audits still include `test-measure2`, `report-benchmark`, `report-size-benchmark`
- [ ] `add-benchmark` now only in informational audits

https://claude.ai/code/session_017gc7dkUxHJ2SRuUJTwf9Gr
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017gc7dkUxHJ2SRuUJTwf9Gr)_