### PR TITLE
fix(config): add unit ns to criterion add benchmark measurement

### DIFF
--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -27,6 +27,13 @@ sigma = 3
 aggregate_by = "min"
 min_measurements = 10
 
+[measurement."bench::add_measurements/add_measurement/1::median"]
+unit = "ns"
+dispersion_method = "mad"
+sigma = 5.0
+aggregate_by = "median"
+min_measurements = 3
+
 [measurement."add-benchmark"]
 epoch = "296bc41"
 unit = "ns"


### PR DESCRIPTION
## Summary

- Adds `[measurement."bench::add_measurements/add_measurement/1::median"]` section to `.gitperfconfig` with `unit = "ns"` so CI audit output formats the Criterion benchmark values as nanoseconds instead of raw numbers.
- Without this, the audit showed `μ: 15,074,993.236` (raw ns) instead of `μ: 15ms`.
- Config mirrors the settings from PR #704 (`dispersion_method = "mad"`, `sigma = 5.0`, `aggregate_by = "median"`, `min_measurements = 3`).

## Test plan

- [ ] CI audit for `bench::add_measurements/add_measurement/1::median` shows formatted values (e.g. `15ms`) rather than raw nanosecond numbers

https://claude.ai/code/session_01EHKFCZ2H2QGKg2ew8zP95k

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHKFCZ2H2QGKg2ew8zP95k)_