### PR TITLE
chore(deps): bump actions/create-github-app-token from 3.1.1 to 3.2.0

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ jobs:
       # Generating a GitHub token, so that PRs and tags created by
       # the release-plz-action can trigger actions workflows.
       - name: Generate GitHub token
-        uses: actions/create-github-app-token@v3.1.1
+        uses: actions/create-github-app-token@v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
$(cat <<'EOF'
Closes #701.

Bumps `actions/create-github-app-token` from 3.1.1 to 3.2.0 in `.github/workflows/release-plz.yml`.

This is a rebase of the Dependabot PR #701 onto the current master (which includes the rust-toolchain 1.96.0 bump), resolving the `test (stable)` CI failure that was unrelated to the original change.

**Changes in 3.2.0:**
- Add support for enterprise-level GitHub Apps
- Support full repository names in `repositories` input
- Validate private-key input
- Bump `@actions/core` from 3.0.0 to 3.0.1

https://claude.ai/code/session_014ZcaWXBv9UJFPFXSENcoqa
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZcaWXBv9UJFPFXSENcoqa)_