### PR TITLE
test(git): reduce log verbosity in concurrency test to expose failures

### DIFF
--- a/test/testslow_concurrency_push_add.sh
+++ b/test/testslow_concurrency_push_add.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 export TEST_TRACE=0
 
-export GIT_TRACE=1
-export RUST_LOG=trace
+export RUST_LOG=warn
 export RUST_BACKTRACE=1
 
 # Scaling factor for iterations (set via environment variable, default to 1)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces `RUST_LOG=trace` and `GIT_TRACE=1` with `RUST_LOG=warn` in `testslow_concurrency_push_add.sh`
- The trace/debug logging was flooding nextest's output buffer (~200KB), causing the actual failure message to be truncated away in CI
- This change makes CI failures observable so the root cause of the flaky test (#697) can be identified

## Context

PR #697 has a flaky `testslow_concurrency_push_add` test failing ~40% of the time on beta CI. The test produces so much trace output that nextest's output buffer overflows before the actual error message is written, making the root cause invisible.

## Test plan

- [ ] Let CI run multiple times on this PR to see if the test now fails with a visible error message
- [ ] Once the root cause is identified, implement a proper fix

https://claude.ai/code/session_01TahqBiHLdpKMbV4vyMCnDr
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TahqBiHLdpKMbV4vyMCnDr)_