### PR TITLE
perf(git_perf): tune add_measurement/1 audit thresholds from baseline study

### DIFF
--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -31,9 +31,13 @@ min_measurements = 10
 epoch = "30c698a"
 unit = "ns"
 dispersion_method = "mad"
-sigma = 5.0
+sigma = 3.5
 aggregate_by = "median"
-min_measurements = 3
+min_measurements = 5
+# Baseline reliability study (10 independent CI runs) measured CoV=8.3%, MAD≈3.4%.
+# min_relative_deviation=10% floor suppresses false positives from normal CI jitter
+# (which peaks at ~8%); sigma=3.5 detects sustained regressions above ~10%.
+min_relative_deviation = 10.0
 
 [measurement."add-benchmark"]
 epoch = "296bc41"


### PR DESCRIPTION
## Summary

Tunes the audit thresholds for `bench::add_measurements/add_measurement/1::median` based on a 10-run baseline reliability study.

## Baseline Measurement Data

10 independent CI runs on `ubuntu-22.04` / `rust=stable` (commit `bacd53a`):

| Stat | Value |
|------|-------|
| Count | 10 |
| Min | 15.017 ms |
| Max | 20.525 ms |
| Mean | 18.746 ms |
| Median | 19.273 ms |
| StdDev | 1.549 ms |
| **CoV** | **8.26%** |

Raw values (ordered by timestamp):

```
[01]  15.017 ms  ← outlier (~22% below cluster)
[02]  19.072 ms
[03]  18.470 ms
[04]  19.550 ms
[05]  19.473 ms
[06]  20.525 ms
[07]  19.767 ms
[08]  19.674 ms
[09]  17.961 ms
[10]  17.953 ms
```

MAD of the 10 runs ≈ **3.4%** relative to median (robust to the one outlier). Without the outlier: CoV ≈ 4.5%.

## Config Changes

| Setting | Before | After | Rationale |
|---------|--------|-------|-----------|
| `sigma` | 5.0 | **3.5** | sigma=5 required a ~17% regression to fire; 3.5 brings detection to ~10%, meaningful for this benchmark |
| `min_relative_deviation` | *(5% default)* | **10.0** | CoV is 8%; a 10% floor prevents false positives from normal CI jitter while still catching real regressions |
| `min_measurements` | 3 | **5** | With 8% CoV, 3 data points gives a noisy MAD estimate; 5 provides substantially better statistical stability |

**Net effect:** detects sustained regressions ≥10% (z > 3.5 *and* deviation > 10%), while the 10% floor suppresses run-to-run noise that falls entirely within the observed CoV band.

## Test plan

- [ ] CI audit passes with new thresholds on next master push
- [ ] No false-positive regression fires within the first 5 measurements after merge

https://claude.ai/code/session_01Y1Hidy3n61FW6go1V73aej

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1Hidy3n61FW6go1V73aej)_