### PR TITLE
perf(ci): replace subprocess report-benchmark with in-process Criterion benchmark

### DIFF
--- a/.git-perf/templates/dashboard-example.html
+++ b/.git-perf/templates/dashboard-example.html
@@ -130,12 +130,24 @@
             }}
         </section>
 
-        <!-- Section 3: Report Benchmark -->
+        <!-- Section 3: Report Benchmark (legacy subprocess) -->
         <section class="report-section">
             <h2>📊 Report Benchmark Performance</h2>
             <p>Median performance for report generation with change point detection and epoch boundaries.</p>
             {{SECTION[report-benchmark]
                 measurement-filter: ^(report-benchmark)$
+                aggregate-by: median
+                show-epochs: true
+                show-changes: true
+            }}
+        </section>
+
+        <!-- Section 3b: Criterion Report Benchmark -->
+        <section class="report-section">
+            <h2>⚡ Criterion Report Benchmark</h2>
+            <p>In-process Criterion benchmark of report generation for 10 commits, with change point detection.</p>
+            {{SECTION[criterion-report-benchmark]
+                measurement-filter: ^bench::report/report_generation/10::median$
                 aggregate-by: median
                 show-epochs: true
                 show-changes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,29 @@ jobs:
             --min-measurements 3 \
             || echo "add benchmark audit failed (expected on first runs)"
 
+    - name: Run report benchmark and track performance
+      env:
+        GIT_AUTHOR_NAME: github-actions[bot]
+        GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        GIT_COMMITTER_NAME: github-actions[bot]
+        GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+      run: |
+          set -x
+          cargo criterion --bench report --features test-helpers --message-format json > report-bench-results.json
+
+          cargo run -- import criterion-json report-bench-results.json \
+            --metadata ci=true \
+            --metadata os=${{matrix.os}} \
+            --metadata rust=${{matrix.rust}}
+
+          cargo run -- push || true
+
+          cargo run -- audit -n 40 \
+            -m "bench::report/report_generation/10::median" \
+            -s os=${{matrix.os}} -s rust=${{matrix.rust}} \
+            --min-measurements 3 \
+            || echo "report benchmark audit failed (expected on first runs)"
+
     - name: Run sample perf measurements
       env:
         GIT_AUTHOR_NAME: github-actions[bot]
@@ -195,10 +218,11 @@ jobs:
           git perf push
 
           # Blocking audits: these must pass or CI fails
-          git perf audit -n 40 -m test-measure2 -m report-benchmark -m report-size-benchmark -m "bench::add_measurements/add_measurement/1::median" -s os=${{matrix.os}} -s rust=${{matrix.rust}}
+          git perf audit -n 40 -m test-measure2 -m report-size-benchmark -m "bench::add_measurements/add_measurement/1::median" -m "bench::report/report_generation/10::median" -s os=${{matrix.os}} -s rust=${{matrix.rust}}
 
           # Informational audits: failures don't block CI
           git perf audit -n 40 -m add-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "add-benchmark audit failed (informational only — replaced by Criterion benchmark)"
+          git perf audit -n 40 -m report-benchmark -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "report-benchmark audit failed (informational only — replaced by Criterion benchmark)"
           git perf audit -n 40 -m report -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "report audit failed (informational only)"
           git perf audit -n 40 -m report-size -s os=${{matrix.os}} -s rust=${{matrix.rust}} || echo "report-size audit failed (informational only)"
 
@@ -310,7 +334,7 @@ jobs:
         with:
           depth: 40
           additional-args: '-s rust'
-          audit-args: '-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m bench::add_measurements/add_measurement/1::median -m release-binary-size --separate-by os --separate-by rust'
+          audit-args: '-m report -m report-size -m report-benchmark -m report-size-benchmark -m add-benchmark -m bench::add_measurements/add_measurement/1::median -m bench::report/report_generation/10::median -m release-binary-size --separate-by os --separate-by rust'
           git-perf-version: 'skip'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           show-size: 'true'

--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -59,3 +59,11 @@ min_relative_deviation = 10.0
 sigma = 3.5
 aggregate_by = "median"
 min_measurements = 10
+
+[measurement."bench::report/report_generation/10::median"]
+unit = "ns"
+dispersion_method = "mad"
+sigma = 3.5
+aggregate_by = "median"
+min_measurements = 5
+min_relative_deviation = 10.0

--- a/git_perf/Cargo.toml
+++ b/git_perf/Cargo.toml
@@ -81,6 +81,12 @@ path = "benches/add.rs"
 required-features = ["test-helpers"]
 
 [[bench]]
+name = "report"
+harness = false
+path = "benches/report.rs"
+required-features = ["test-helpers"]
+
+[[bench]]
 name = "sample_ci_bench"
 harness = false
 path = "benches/sample_ci_bench.rs"

--- a/git_perf/benches/report.rs
+++ b/git_perf/benches/report.rs
@@ -1,0 +1,72 @@
+use std::env::set_current_dir;
+use std::process::Command;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use git_perf::test_helpers::{empty_commit, hermetic_git_env};
+use tempfile::tempdir;
+
+fn prep_repo(num_commits: usize, num_measurements: usize) -> tempfile::TempDir {
+    let temp_dir = tempdir().unwrap();
+
+    set_current_dir(temp_dir.path()).expect("Failed to change current path");
+    hermetic_git_env();
+
+    // Explicit --initial-branch for consistent behaviour across git versions.
+    assert!(Command::new("git")
+        .args(["init", "--initial-branch", "master"])
+        .output()
+        .expect("Failed to init git repo")
+        .status
+        .success());
+
+    empty_commit();
+
+    for _ in 0..num_commits {
+        empty_commit();
+        let measurements = vec![100.0; num_measurements];
+        git_perf::measurement_storage::add_multiple("benchmark-a", &measurements, &[])
+            .expect("Could not add measurements");
+    }
+
+    temp_dir
+}
+
+fn report_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("report");
+    group.sample_size(10);
+
+    let num_commits = 10;
+    let num_measurements = 10;
+
+    let _temp_dir = prep_repo(num_commits, num_measurements);
+
+    group.throughput(Throughput::Elements(num_commits as u64));
+    group.bench_function(BenchmarkId::new("report_generation", num_commits), |b| {
+        b.iter(|| {
+            git_perf::reporting::report(
+                "HEAD",
+                std::path::PathBuf::from("report.html"),
+                vec![],
+                num_commits,
+                None,
+                None,
+                &[],
+                None,
+                &[],
+                git_perf::reporting::ReportTemplateConfig {
+                    template_path: None,
+                    custom_css_path: None,
+                    title: None,
+                },
+                false,
+                false,
+            )
+            .expect("Report generation failed");
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, report_generation);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Adds `git_perf/benches/report.rs`: a Criterion benchmark that calls `reporting::report()` in-process on a hermetic 10-commit × 10-measurement temp repo, matching the scale used by the old subprocess benchmark
- Adds a new CI step "Run report benchmark and track performance" (pattern mirrors the add benchmark step) that runs the Criterion bench, imports results, and audits `bench::report/report_generation/10::median`
- Promotes `bench::report/report_generation/10::median` to the blocking audit; demotes the old `report-benchmark` subprocess measurement to informational-only (kept for historical continuity)
- Adds `.gitperfconfig` entry and dashboard template section for the new Criterion measurement

## Test plan

- [ ] `cargo build --bench report --features test-helpers` compiles cleanly
- [ ] `cargo bench --bench report --features test-helpers -- --test` passes (smoke-tested locally — "Success")
- [ ] `cargo fmt --check` and `cargo clippy` pass
- [ ] CI blocking audit uses `bench::report/report_generation/10::median` instead of `report-benchmark`

https://claude.ai/code/session_01ArUqvaZarZPvXUJ8h18Us7

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArUqvaZarZPvXUJ8h18Us7)_