### PR TITLE
feat(git_perf): add study command for pre-merge benchmark COV tuning

### DIFF
--- a/.github/workflows/benchmark-study.yml
+++ b/.github/workflows/benchmark-study.yml
@@ -1,0 +1,155 @@
+name: Benchmark Study
+
+# Reusable workflow for cross-runner variance analysis.
+# Run this on a PR branch before merging a new benchmark to measure
+# between-runner CoV and get recommended .gitperfconfig settings.
+#
+# Usage from an external repo:
+#   jobs:
+#     study:
+#       uses: kaihowl/git-perf/.github/workflows/benchmark-study.yml@VERSION
+#       with:
+#         measurement: bench::my_benchmark/operation::min
+#         command: cargo bench --bench my_benchmark
+#       secrets: inherit
+
+on:
+  workflow_dispatch:
+    inputs:
+      measurement:
+        description: >
+          Full measurement name (e.g. bench::add_measurements/add_measurement/1::median).
+          Must match the name used in the measure/import step.
+        required: true
+        type: string
+      command:
+        description: >
+          Command that runs the benchmark (e.g. cargo bench --bench my_bench).
+          Wrap multi-word commands in quotes.
+        required: true
+        type: string
+      instances:
+        description: Number of independent runner instances (≥ 3 required, 10 recommended)
+        required: false
+        default: '10'
+        type: string
+      reps_per_instance:
+        description: Repetitions per runner instance passed to git-perf measure -n
+        required: false
+        default: '10'
+        type: string
+      max_cov:
+        description: >
+          Fail if between-runner CoV exceeds this percentage (leave empty to only report).
+          Recommended: 20 for a hard gate, or leave empty during initial exploration.
+        required: false
+        default: ''
+        type: string
+
+  workflow_call:
+    inputs:
+      measurement:
+        required: true
+        type: string
+      command:
+        required: true
+        type: string
+      instances:
+        required: false
+        default: '10'
+        type: string
+      reps_per_instance:
+        required: false
+        default: '10'
+        type: string
+      max_cov:
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  measure:
+    name: Measure (instance ${{ matrix.instance }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      # Generate a matrix from 1..instances. GitHub Actions doesn't support
+      # dynamic matrix sizes natively, so we hardcode up to 10 instances and
+      # trim via the 'if' condition below.
+      matrix:
+        instance: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    # Only run the instances the user requested
+    if: ${{ matrix.instance <= fromJSON(inputs.instances) }}
+
+    env:
+      GIT_AUTHOR_NAME: github-actions[bot]
+      GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+      GIT_COMMITTER_NAME: github-actions[bot]
+      GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history so git-perf can walk commits for push/pull
+          fetch-depth: 0
+
+      - name: Install git-perf
+        uses: kaihowl/git-perf/.github/actions/install@main
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run benchmark and record measurements
+        run: |
+          git perf measure \
+            -n "${{ inputs.reps_per_instance }}" \
+            -m "${{ inputs.measurement }}" \
+            --key-value group=${{ matrix.instance }} \
+            -- ${{ inputs.command }}
+
+      - name: Push measurements
+        run: git perf push
+
+  study:
+    name: Analyze cross-runner variance
+    runs-on: ubuntu-22.04
+    needs: measure
+    if: always() && needs.measure.result != 'skipped'
+
+    env:
+      GIT_AUTHOR_NAME: github-actions[bot]
+      GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+      GIT_COMMITTER_NAME: github-actions[bot]
+      GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install git-perf
+        uses: kaihowl/git-perf/.github/actions/install@main
+
+      - name: Pull measurements from all runners
+        run: git perf pull
+
+      - name: Run study analysis
+        run: |
+          MAX_COV_FLAG=""
+          if [ -n "${{ inputs.max_cov }}" ]; then
+            MAX_COV_FLAG="--max-cov ${{ inputs.max_cov }}"
+          fi
+          git perf study -m "${{ inputs.measurement }}" $MAX_COV_FLAG

--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -661,7 +661,7 @@ pub enum Commands {
 
         /// Metadata key used to identify independent runner groups.
         /// Each matrix instance should tag its measurements with
-        /// --key-value <group-by>=<instance-number>.
+        /// `--key-value <KEY>=<INSTANCE_NUMBER>`.
         #[arg(long, default_value = "group")]
         group_by: String,
     },

--- a/cli_types/src/lib.rs
+++ b/cli_types/src/lib.rs
@@ -609,6 +609,63 @@ pub enum Commands {
         include_objects: bool,
     },
 
+    /// Analyze cross-runner variance to recommend .gitperfconfig settings
+    ///
+    /// Reads measurements at HEAD that were collected from multiple independent
+    /// runner instances (each tagged with a group key via --key-value group=N),
+    /// computes between-group CoV (Coefficient of Variation), and outputs
+    /// recommended .gitperfconfig parameters.
+    ///
+    /// ## Workflow
+    ///
+    /// 1. Run the benchmark on N independent CI runners (use a matrix strategy).
+    ///    Each runner stores its measurements and tags them with a group key:
+    ///    `git-perf measure -n 10 -m MEASUREMENT --key-value group=$INSTANCE -- COMMAND`
+    ///    `git-perf push`
+    ///
+    /// 2. After all runners finish, pull and run study:
+    ///    `git-perf pull`
+    ///    `git-perf study -m MEASUREMENT`
+    ///
+    /// ## Interpretation
+    ///
+    /// - CoV < 10%: stable benchmark — use the recommended config as-is
+    /// - CoV 10–20%: moderate noise — monitor with max_cov and consider increasing workload
+    /// - CoV > 20%: too noisy — improve benchmark isolation before merging
+    ///
+    /// ## Examples
+    ///
+    /// ```bash
+    /// # Analyze cross-runner variance for a specific measurement
+    /// git-perf study -m bench::add_measurements/add_measurement/1::median
+    ///
+    /// # Fail if CoV exceeds 20% (useful as a CI gate on PRs)
+    /// git-perf study -m bench::my_benchmark --max-cov 20
+    /// ```
+    Study {
+        /// Name of the measurement to analyze
+        #[arg(short = 'm', long = "measurement", value_parser=parse_spaceless_string, required = true)]
+        name: String,
+
+        /// Limit the number of previous commits considered (HEAD is included)
+        #[arg(short = 'n', long, default_value = "50")]
+        max_count: usize,
+
+        /// Fail if between-group CoV exceeds this percentage
+        #[arg(long)]
+        max_cov: Option<f64>,
+
+        /// Target commit to study (default: HEAD)
+        #[arg(long = "commit", value_name = "COMMIT")]
+        commit: Option<String>,
+
+        /// Metadata key used to identify independent runner groups.
+        /// Each matrix instance should tag its measurements with
+        /// --key-value <group-by>=<instance-number>.
+        #[arg(long, default_value = "group")]
+        group_by: String,
+    },
+
     /// Manage git-perf configuration
     ///
     /// Display and query git-perf configuration settings, including git context

--- a/docs/benchmark-study.md
+++ b/docs/benchmark-study.md
@@ -1,5 +1,7 @@
 # Benchmark Study Guide
 
+> **Experimental**: The `git perf study` command and the reusable benchmark-study workflow are new and may change in future releases. Feedback welcome.
+
 Before adding a new benchmark to your CI performance suite, run a **benchmark study** to measure its cross-runner variability (Coefficient of Variation) and get recommended `.gitperfconfig` settings. This prevents noisy benchmarks from causing false audit failures after merging.
 
 ## Why a study?

--- a/docs/benchmark-study.md
+++ b/docs/benchmark-study.md
@@ -1,0 +1,155 @@
+# Benchmark Study Guide
+
+Before adding a new benchmark to your CI performance suite, run a **benchmark study** to measure its cross-runner variability (Coefficient of Variation) and get recommended `.gitperfconfig` settings. This prevents noisy benchmarks from causing false audit failures after merging.
+
+## Why a study?
+
+Performance benchmarks on shared CI infrastructure vary between runner instances due to hardware differences, load, and scheduling. A benchmark with 15% cross-runner CoV will trigger false regression alerts constantly. The study workflow measures this variance and tells you exactly how to configure the benchmark to tolerate it.
+
+## Setup (once per repository)
+
+Add a wrapper workflow to your repo so you can trigger studies on demand:
+
+```yaml
+# .github/workflows/benchmark-study.yml
+on:
+  workflow_dispatch:
+    inputs:
+      measurement:
+        description: Full measurement name (e.g. bench::my_bench/op::min)
+        required: true
+        type: string
+      command:
+        description: Command that runs the benchmark
+        required: true
+        type: string
+      instances:
+        description: Number of independent runners (≥ 3; default 10)
+        required: false
+        default: '10'
+        type: string
+      reps_per_instance:
+        description: Repetitions per runner passed to git-perf measure -n
+        required: false
+        default: '10'
+        type: string
+      max_cov:
+        description: Fail if CoV exceeds this % (leave empty to only report)
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  study:
+    uses: kaihowl/git-perf/.github/workflows/benchmark-study.yml@VERSION
+    with:
+      measurement: ${{ inputs.measurement }}
+      command: ${{ inputs.command }}
+      instances: ${{ inputs.instances }}
+      reps_per_instance: ${{ inputs.reps_per_instance }}
+      max_cov: ${{ inputs.max_cov }}
+    secrets: inherit
+```
+
+Replace `VERSION` with a specific git-perf release tag (e.g. `v0.18.0`) for stability.
+
+**Prerequisites**: The reusable workflow installs git-perf automatically using the [install action](../../../.github/actions/install). Your repository must have push access to the git-perf notes ref (`refs/notes/perf-v3`), which requires `contents: write` permission for the workflow.
+
+## When to run a study
+
+- **When adding a new benchmark** to CI before merging the PR
+- **When an existing benchmark starts producing noisy audits** (unexplained failures)
+- **After changing a benchmark's workload**, setup, or iteration count
+
+## How to trigger it
+
+1. Push your PR branch
+2. Go to **Actions → Benchmark Study → Run workflow**
+3. Select your PR branch
+4. Enter:
+   - **measurement**: the exact name git-perf will use (e.g. `bench::my_bench/sorting/1000::median`)
+   - **command**: the shell command that runs the benchmark (e.g. `cargo bench --bench my_bench`)
+   - **instances**: number of parallel runners (default 10; minimum 3)
+   - **reps_per_instance**: repetitions per runner (default 10)
+5. Click **Run workflow** and wait for the `study` job to finish
+
+The study output appears in the **Analyze cross-runner variance** job log.
+
+## How it works
+
+The workflow runs in two stages:
+
+1. **Measure** (parallel): Each of the N runner instances runs the benchmark independently and stores its measurements via `git-perf measure --key-value group=<instance>` then pushes them to the remote notes ref.
+
+2. **Study** (sequential): After all measure jobs finish, pulls all measurements and runs `git-perf study -m MEASUREMENT`. The command groups measurements by the `group` key, computes a **per-group minimum** (to reduce within-runner noise), then computes statistics over those N per-group values to produce the **between-runner CoV**.
+
+## Interpreting results
+
+The study output looks like:
+
+```
+📊 'bench::my_benchmark/sort/1000::min' — 10 groups × 10 reps (grouped by: group)
+  μ: 45.2µs | σ: 3.8µs | MAD: 2.1µs
+  Between-group CoV: 8.4% | MAD%: 4.6% | MAD/σ: 0.55
+
+  ✅ CoV < 10%: benchmark is stable.
+
+  Recommended .gitperfconfig:
+  [measurement."bench::my_benchmark/sort/1000::min"]
+  dispersion_method = "mad"  # MAD/σ = 0.55 — outliers between runners detected
+  sigma = 3.5                # tightened threshold for CoV > 5%
+  aggregate_by = "min"
+  min_measurements = 3
+  min_relative_deviation = 13.0  # 1.5× between-group CoV — noise floor
+  max_cov = 17.0                 # warn if noise grows to 2× current level
+```
+
+**CoV verdict**:
+
+| CoV | Verdict | Action |
+|-----|---------|--------|
+| < 10% | ✅ Stable | Use the recommended config and merge |
+| 10–20% | ⚠️ Moderate | Use the config, monitor with `max_cov` |
+| > 20% | ⚠️ Noisy | Improve benchmark isolation before merging |
+
+## Applying the recommendations
+
+1. Copy the `[measurement."..."]` TOML block from the study output
+2. Paste it into `.gitperfconfig` in your repository
+3. Commit it alongside the new benchmark
+
+The config block tells git-perf's `audit` command how to interpret this benchmark's noise level, preventing false alarms.
+
+## What to do if CoV is too high
+
+If your benchmark shows CoV > 20%, consider:
+
+- **Increase workload size**: more work per iteration reduces relative setup noise
+- **Add warmup**: run the benchmark once before measuring (e.g. `--warm-up-time 3s` in Criterion)
+- **Isolate I/O**: avoid filesystem, network, or database operations in the timed section
+- **Increase `reps_per_instance`**: more reps per runner let `min` aggregation absorb outliers
+- **Pin to a fixed-spec runner**: use `runs-on: [self-hosted, perf]` with dedicated hardware
+
+After improving isolation, re-run the study and compare the new CoV.
+
+## Using the study as a CI gate
+
+To prevent noisy benchmarks from being merged, add `max_cov` to the study trigger:
+
+```yaml
+# In your PR workflow
+- name: Benchmark stability gate
+  uses: kaihowl/git-perf/.github/workflows/benchmark-study.yml@VERSION
+  with:
+    measurement: bench::my_bench/op::min
+    command: cargo bench --bench my_bench
+    max_cov: '20'   # Fail if CoV exceeds 20%
+```
+
+The workflow exits with code 1 if the measured CoV exceeds `max_cov`, blocking the PR merge.
+
+## See also
+
+- [Integration Tutorial](INTEGRATION_TUTORIAL.md) — full CI setup guide
+- [`.gitperfconfig` reference](manpage.md) — all available config options
+- `git perf study --help` — CLI reference

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -435,7 +435,7 @@ Reads measurements at HEAD that were collected from multiple independent runner 
   Default value: `50`
 * `--max-cov <MAX_COV>` — Fail if between-group CoV exceeds this percentage
 * `--commit <COMMIT>` — Target commit to study (default: HEAD)
-* `--group-by <GROUP_BY>` — Metadata key used to identify independent runner groups. Each matrix instance should tag its measurements with --key-value <group-by>=<instance-number>
+* `--group-by <GROUP_BY>` — Metadata key used to identify independent runner groups. Each matrix instance should tag its measurements with `--key-value <KEY>=<INSTANCE_NUMBER>`
 
   Default value: `group`
 

--- a/docs/manpage.md
+++ b/docs/manpage.md
@@ -19,6 +19,7 @@ This document contains the help content for the `git-perf` command-line program.
 * [`git-perf reset`↴](#git-perf-reset)
 * [`git-perf list-commits`↴](#git-perf-list-commits)
 * [`git-perf size`↴](#git-perf-size)
+* [`git-perf study`↴](#git-perf-study)
 * [`git-perf config`↴](#git-perf-config)
 
 ## `git-perf`
@@ -41,6 +42,7 @@ This document contains the help content for the `git-perf` command-line program.
 * `reset` — Drop locally pending measurements that haven't been pushed
 * `list-commits` — List all commits that have performance measurements
 * `size` — Estimate storage size of live performance measurements
+* `study` — Analyze cross-runner variance to recommend .gitperfconfig settings
 * `config` — Manage git-perf configuration
 
 ###### **Options:**
@@ -398,6 +400,44 @@ Examples: git perf size                    # Show total size in human-readable f
 
 * `--disk-size` — Use on-disk size (compressed) instead of logical size
 * `--include-objects` — Include git repository statistics for context
+
+
+
+## `git-perf study`
+
+Analyze cross-runner variance to recommend .gitperfconfig settings
+
+Reads measurements at HEAD that were collected from multiple independent runner instances (each tagged with a group key via --key-value group=N), computes between-group CoV (Coefficient of Variation), and outputs recommended .gitperfconfig parameters.
+
+## Workflow
+
+1. Run the benchmark on N independent CI runners (use a matrix strategy). Each runner stores its measurements and tags them with a group key: `git-perf measure -n 10 -m MEASUREMENT --key-value group=$INSTANCE -- COMMAND` `git-perf push`
+
+2. After all runners finish, pull and run study: `git-perf pull` `git-perf study -m MEASUREMENT`
+
+## Interpretation
+
+- CoV < 10%: stable benchmark — use the recommended config as-is - CoV 10–20%: moderate noise — monitor with max_cov and consider increasing workload - CoV > 20%: too noisy — improve benchmark isolation before merging
+
+## Examples
+
+```bash # Analyze cross-runner variance for a specific measurement git-perf study -m bench::add_measurements/add_measurement/1::median
+
+# Fail if CoV exceeds 20% (useful as a CI gate on PRs) git-perf study -m bench::my_benchmark --max-cov 20 ```
+
+**Usage:** `git-perf study [OPTIONS] --measurement <NAME>`
+
+###### **Options:**
+
+* `-m`, `--measurement <NAME>` — Name of the measurement to analyze
+* `-n`, `--max-count <MAX_COUNT>` — Limit the number of previous commits considered (HEAD is included)
+
+  Default value: `50`
+* `--max-cov <MAX_COV>` — Fail if between-group CoV exceeds this percentage
+* `--commit <COMMIT>` — Target commit to study (default: HEAD)
+* `--group-by <GROUP_BY>` — Metadata key used to identify independent runner groups. Each matrix instance should tag its measurements with --key-value <group-by>=<instance-number>
+
+  Default value: `group`
 
 
 

--- a/git_perf/src/cli.rs
+++ b/git_perf/src/cli.rs
@@ -17,6 +17,7 @@ use crate::reset;
 use crate::size;
 use crate::stats::ReductionFunc;
 use crate::status;
+use crate::study;
 use git_perf_cli_types::{Cli, Commands};
 
 pub fn handle_calls() -> Result<()> {
@@ -207,6 +208,16 @@ pub fn handle_calls() -> Result<()> {
             disk_size,
             include_objects,
         } => size::calculate_measurement_size(detailed, format, disk_size, include_objects),
+        Commands::Study {
+            name,
+            max_count,
+            max_cov,
+            commit,
+            group_by,
+        } => {
+            let commit = commit.as_deref().unwrap_or("HEAD");
+            study::run_study(commit, max_count, &name, max_cov, &group_by)
+        }
         Commands::Config {
             list,
             detailed,

--- a/git_perf/src/lib.rs
+++ b/git_perf/src/lib.rs
@@ -20,6 +20,7 @@ pub mod serialization;
 pub mod size;
 pub mod stats;
 pub mod status;
+pub mod study;
 pub mod units;
 
 // Test helpers module - made public for use in unit tests, integration tests, and benchmarks

--- a/git_perf/src/study.rs
+++ b/git_perf/src/study.rs
@@ -71,6 +71,20 @@ fn is_mad_preferred(mad_sigma_ratio: f64, n: usize) -> bool {
     mad_sigma_ratio < 0.7 && n >= 5
 }
 
+/// Recommended sigma for given CoV. Returns 3.5 if CoV > 5%, otherwise 4.0.
+fn recommend_sigma(cov: f64) -> f64 {
+    if cov > 5.0 {
+        3.5_f64
+    } else {
+        4.0_f64
+    }
+}
+
+/// Returns true if CoV strictly exceeds the threshold (NaN-safe: NaN > x = false).
+fn exceeds_cov_threshold(cov: f64, threshold: f64) -> bool {
+    cov > threshold
+}
+
 /// Compute recommendations from between-group aggregate values.
 /// Returns None if there are fewer than 3 data points.
 #[must_use]
@@ -93,7 +107,7 @@ pub fn compute_recommendations(aggregates: &[f64]) -> Option<Recommendations> {
         "stddev"
     };
     let aggregate_by = if cov > 10.0 { "median" } else { "min" };
-    let sigma = if cov > 5.0 { 3.5_f64 } else { 4.0_f64 };
+    let sigma = recommend_sigma(cov);
     let min_measurements: u16 = if cov > 10.0 { 5 } else { 3 };
     // Round up to nearest 0.5 for readability
     let min_relative_deviation = (cov * 1.5 * 2.0).ceil() / 2.0;
@@ -200,7 +214,7 @@ pub(crate) fn format_output(
     // CoV verdict
     if !cov.is_nan() {
         let verdict = if let Some(threshold) = max_cov_threshold {
-            if cov > threshold {
+            if exceeds_cov_threshold(cov, threshold) {
                 format!(
                     "\n  ⚠️  CoV {:.1}% exceeds threshold {:.1}% — \
                      benchmark may produce unreliable CI results.\n\
@@ -241,7 +255,7 @@ pub(crate) fn format_output(
             ));
         }
         out.push_str(&format!("\n  sigma = {}", recs.sigma));
-        if cov > 5.0 {
+        if recs.sigma < 4.0 {
             out.push_str("  # tightened threshold for CoV > 5%");
         }
         out.push_str(&format!("\n  aggregate_by = \"{}\"", recs.aggregate_by));
@@ -323,8 +337,8 @@ pub fn run_study(
     if let Some(threshold) = max_cov_threshold {
         let stats = aggregate_measurements(group_aggregates.iter());
         let cov = compute_cov_pct(stats.stddev, stats.mean);
-        // NaN > threshold is false per IEEE 754, so near-zero means safely skip the gate
-        if cov > threshold {
+        // NaN is treated as not exceeding: exceeds_cov_threshold returns false for NaN
+        if exceeds_cov_threshold(cov, threshold) {
             bail!("CoV {:.1}% exceeds threshold {:.1}%", cov, threshold);
         }
     }
@@ -488,12 +502,17 @@ mod tests {
             !out_low.contains("tightened threshold"),
             "low CoV should NOT have sigma tightened comment:\n{out_low}"
         );
+        // Use specific unique strings to distinguish the two CoV > 10% comment locations
         assert!(
-            !out_low.contains("CoV > 10%"),
-            "low CoV should NOT have CoV>10% config comment:\n{out_low}"
+            !out_low.contains("median more stable than min"),
+            "low CoV should NOT have aggregate_by comment:\n{out_low}"
+        );
+        assert!(
+            !out_low.contains("need more history"),
+            "low CoV should NOT have min_measurements comment:\n{out_low}"
         );
 
-        // High CoV (≈ 12%): sigma and CoV>10% comments should appear
+        // High CoV (≈ 12%): sigma and BOTH CoV>10% comments should appear
         let high_cov = vec![100.0, 112.0, 88.0, 115.0, 85.0, 110.0];
         let out_high = format_output("bench", &high_cov, true, 60, "group", None);
         assert!(
@@ -501,8 +520,12 @@ mod tests {
             "high CoV should have sigma tightened comment:\n{out_high}"
         );
         assert!(
-            out_high.contains("CoV > 10%"),
-            "high CoV should have CoV>10% config comment:\n{out_high}"
+            out_high.contains("median more stable than min"),
+            "high CoV should have aggregate_by comment:\n{out_high}"
+        );
+        assert!(
+            out_high.contains("need more history"),
+            "high CoV should have min_measurements comment:\n{out_high}"
         );
     }
 
@@ -721,5 +744,66 @@ mod tests {
         assert!(!is_mad_preferred(0.5, 4));
         // n=5 with low ratio: preferred
         assert!(is_mad_preferred(0.5, 5));
+    }
+
+    #[test]
+    fn test_threshold_helpers() {
+        // recommend_sigma: literal 5.0 distinguishes > 5.0 from >= 5.0
+        assert_eq!(recommend_sigma(5.0), 4.0, "5.0 is NOT > 5.0");
+        assert_eq!(recommend_sigma(5.1), 3.5, "5.1 IS > 5.0");
+        // exceeds_cov_threshold: literal equality distinguishes > from >=
+        assert!(!exceeds_cov_threshold(10.0, 10.0), "10.0 is NOT > 10.0");
+        assert!(exceeds_cov_threshold(10.1, 10.0), "10.1 IS > 10.0");
+    }
+
+    #[test]
+    fn test_recommendations_near_10pct_boundary() {
+        // [90, 100, 110]: Welford gives exact M2=200 → stddev=10.0, mean=100.0
+        // cov = 10.0/100.0*100.0 = 10.0 (IEEE 754 rounds down, excess < half ULP)
+        // cov > 10.0 = false → kills > 10.0 → >= 10.0 mutations in compute_recommendations
+        let data = vec![90.0, 100.0, 110.0];
+        let recs = compute_recommendations(&data).unwrap();
+        assert_eq!(recs.aggregate_by, "min", "cov=10.0 is NOT > 10.0 → min");
+        assert_eq!(
+            recs.min_measurements, 3,
+            "cov=10.0 is NOT > 10.0 → min_measurements=3"
+        );
+    }
+
+    #[test]
+    fn test_format_output_near_10pct_boundary() {
+        // [90, 100, 110]: cov=10.0 exactly (NOT > 10.0)
+        // Kills > 10.0 → >= 10.0 mutations in the three format_output threshold checks
+        let data = vec![90.0, 100.0, 110.0];
+        let out = format_output("bench", &data, true, 3, "group", None);
+        assert!(
+            out.contains("stable"),
+            "cov=10.0 is NOT > 10.0 → stable:\n{out}"
+        );
+        assert!(
+            !out.contains("median more stable than min"),
+            "cov=10.0 → no aggregate_by comment:\n{out}"
+        );
+        assert!(
+            !out.contains("need more history"),
+            "cov=10.0 → no min_measurements comment:\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_near_20pct_boundary() {
+        // [80, 100, 120]: Welford gives exact M2=800 → stddev=20.0, mean=100.0
+        // cov = 20.0/100.0*100.0 = 20.0 (IEEE 754 rounds down, exact)
+        // cov > 20.0 = false → kills > 20.0 → >= 20.0 mutation in format_output verdict
+        let data = vec![80.0, 100.0, 120.0];
+        let out = format_output("bench", &data, true, 3, "group", None);
+        assert!(
+            !out.contains("too noisy"),
+            "cov=20.0 is NOT > 20.0 → not too noisy:\n{out}"
+        );
+        assert!(
+            out.contains("10\u{2013}20%") || out.contains("moderate"),
+            "cov=20.0 >= 10.0 → moderate verdict:\n{out}"
+        );
     }
 }

--- a/git_perf/src/study.rs
+++ b/git_perf/src/study.rs
@@ -106,7 +106,34 @@ pub fn compute_recommendations(aggregates: &[f64]) -> Option<Recommendations> {
     })
 }
 
-fn format_output(
+/// Compute between-group CoV as a percentage. Returns NaN when mean is near zero.
+fn compute_cov_pct(stddev: f64, mean: f64) -> f64 {
+    if mean.abs() > f64::EPSILON && !mean.is_nan() {
+        stddev / mean * 100.0
+    } else {
+        f64::NAN
+    }
+}
+
+/// Compute MAD as a percentage of the mean. Returns NaN when mean is near zero.
+fn compute_mad_pct(mad: f64, mean: f64) -> f64 {
+    if mean.abs() > f64::EPSILON && !mean.is_nan() {
+        mad / mean.abs() * 100.0
+    } else {
+        f64::NAN
+    }
+}
+
+/// Compute MAD/σ ratio. Returns NaN when stddev is near zero.
+fn compute_mad_sigma_ratio(mad: f64, stddev: f64) -> f64 {
+    if stddev > f64::EPSILON {
+        mad / stddev
+    } else {
+        f64::NAN
+    }
+}
+
+pub(crate) fn format_output(
     name: &str,
     aggregates: &[f64],
     grouped_by_key: bool,
@@ -116,21 +143,9 @@ fn format_output(
 ) -> String {
     let stats = aggregate_measurements(aggregates.iter());
     let n = aggregates.len();
-    let cov = if stats.mean.abs() > f64::EPSILON && !stats.mean.is_nan() {
-        stats.stddev / stats.mean * 100.0
-    } else {
-        f64::NAN
-    };
-    let mad_pct = if stats.mean.abs() > f64::EPSILON && !stats.mean.is_nan() {
-        stats.mad / stats.mean.abs() * 100.0
-    } else {
-        f64::NAN
-    };
-    let mad_sigma_ratio = if stats.stddev > f64::EPSILON {
-        stats.mad / stats.stddev
-    } else {
-        f64::NAN
-    };
+    let cov = compute_cov_pct(stats.stddev, stats.mean);
+    let mad_pct = compute_mad_pct(stats.mad, stats.mean);
+    let mad_sigma_ratio = compute_mad_sigma_ratio(stats.mad, stats.stddev);
 
     let cov_label = if grouped_by_key {
         "Between-group CoV"
@@ -304,11 +319,8 @@ pub fn run_study(
 
     if let Some(threshold) = max_cov_threshold {
         let stats = aggregate_measurements(group_aggregates.iter());
-        let cov = if stats.mean.abs() > f64::EPSILON {
-            stats.stddev / stats.mean * 100.0
-        } else {
-            0.0
-        };
+        let cov = compute_cov_pct(stats.stddev, stats.mean);
+        // NaN > threshold is false per IEEE 754, so near-zero means safely skip the gate
         if cov > threshold {
             bail!("CoV {:.1}% exceeds threshold {:.1}%", cov, threshold);
         }
@@ -358,20 +370,196 @@ mod tests {
 
     #[test]
     fn test_recommend_rounding() {
-        // CoV = 8.4% → min_relative_deviation = ceil(8.4 * 1.5 * 2) / 2 = ceil(25.2) / 2 = 26/2 = 13.0
-        // We can't easily control exact CoV, but check that rounding is to nearest 0.5
+        // data: [100.0, 108.0, 100.5, 107.5, 99.5, 108.5]
+        // mean=104, stddev=sqrt(97/5)≈4.405, cov≈4.235%
+        // min_relative_deviation = ceil(4.235 * 1.5 * 2.0) / 2.0 = ceil(12.705) / 2 = 6.5
+        // max_cov              = ceil(4.235 * 2.0 * 2.0) / 2.0 = ceil(16.94)  / 2 = 8.5
         let recs = compute_recommendations(&[100.0, 108.0, 100.5, 107.5, 99.5, 108.5]).unwrap();
-        // Result should be a multiple of 0.5
+        // Check exact values so mutations to the rounding formula are caught
+        assert!(
+            (recs.min_relative_deviation - 6.5).abs() < 0.01,
+            "expected min_relative_deviation=6.5, got {}",
+            recs.min_relative_deviation
+        );
+        assert!(
+            (recs.max_cov - 8.5).abs() < 0.01,
+            "expected max_cov=8.5, got {}",
+            recs.max_cov
+        );
+        // Result should also be a multiple of 0.5
         let scaled = recs.min_relative_deviation * 2.0;
         assert!(
             (scaled - scaled.round()).abs() < f64::EPSILON,
             "min_relative_deviation should be a multiple of 0.5"
         );
-        let scaled_cov = recs.max_cov * 2.0;
-        assert!(
-            (scaled_cov - scaled_cov.round()).abs() < f64::EPSILON,
-            "max_cov should be a multiple of 0.5"
+    }
+
+    #[test]
+    fn test_recommend_dispersion_method_boundary() {
+        // n=4 with one extreme outlier: MAD/σ ≈ 0, but n < 5 → "stddev"
+        let data_4 = vec![100.0, 100.0, 100.0, 200.0];
+        let recs_4 = compute_recommendations(&data_4).unwrap();
+        assert_eq!(
+            recs_4.dispersion_method, "stddev",
+            "n=4 should use stddev regardless of MAD/σ"
         );
+
+        // n=5 same pattern: MAD/σ ≈ 0 and n >= 5 → "mad"
+        let data_5 = vec![100.0, 100.0, 100.0, 100.0, 200.0];
+        let recs_5 = compute_recommendations(&data_5).unwrap();
+        assert_eq!(
+            recs_5.dispersion_method, "mad",
+            "n=5 with low MAD/σ should use mad"
+        );
+    }
+
+    #[test]
+    fn test_compute_helpers() {
+        // compute_cov_pct: normal input
+        let cov = compute_cov_pct(10.0, 100.0);
+        assert!((cov - 10.0).abs() < 1e-9, "cov should be 10%, got {cov}");
+
+        // compute_cov_pct: near-zero mean → NaN
+        assert!(compute_cov_pct(1.0, 0.0).is_nan());
+
+        // compute_cov_pct: exact-EPSILON mean → NaN (EPSILON > EPSILON is false)
+        assert!(compute_cov_pct(1.0, f64::EPSILON).is_nan());
+
+        // compute_mad_pct: normal input
+        let mp = compute_mad_pct(5.0, 100.0);
+        assert!((mp - 5.0).abs() < 1e-9, "mad_pct should be 5%, got {mp}");
+
+        // compute_mad_pct: near-zero mean → NaN
+        assert!(compute_mad_pct(1.0, 0.0).is_nan());
+
+        // compute_mad_sigma_ratio: normal input
+        let r = compute_mad_sigma_ratio(3.0, 6.0);
+        assert!((r - 0.5).abs() < 1e-9, "ratio should be 0.5, got {r}");
+
+        // compute_mad_sigma_ratio: near-zero stddev → NaN
+        assert!(compute_mad_sigma_ratio(1.0, 0.0).is_nan());
+    }
+
+    #[test]
+    fn test_format_output_verdict_low_cov() {
+        // CoV < 10% → "stable" verdict
+        let aggregates = vec![100.0, 100.5, 99.5, 100.2, 100.8, 99.8];
+        let out = format_output("bench", &aggregates, true, 6, "group", None);
+        assert!(
+            out.contains("stable"),
+            "low CoV should give stable verdict:\n{out}"
+        );
+        assert!(out.contains("Between-group CoV"), "grouped output:\n{out}");
+    }
+
+    #[test]
+    fn test_format_output_verdict_moderate_cov() {
+        // CoV 10–20%: values with ~13% spread
+        let aggregates = vec![100.0, 112.0, 88.0, 115.0, 85.0, 110.0];
+        let out = format_output("bench", &aggregates, true, 60, "group", None);
+        // Moderate verdict contains "10–20%" and does not contain the stable/noisy verdicts
+        assert!(
+            out.contains("10\u{2013}20%"),
+            "moderate CoV should show 10–20% range:\n{out}"
+        );
+        assert!(
+            !out.contains("benchmark is stable"),
+            "moderate should NOT say 'benchmark is stable':\n{out}"
+        );
+        assert!(
+            !out.contains("too noisy"),
+            "moderate should NOT say too noisy:\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_verdict_high_cov() {
+        // CoV > 20%: wide spread
+        let aggregates = vec![100.0, 130.0, 70.0, 145.0, 60.0, 125.0, 75.0];
+        let out = format_output("bench", &aggregates, true, 700, "group", None);
+        assert!(
+            out.contains("too noisy"),
+            "high CoV should give too noisy verdict:\n{out}"
+        );
+        assert!(
+            !out.contains("benchmark is stable"),
+            "high CoV should NOT say 'benchmark is stable':\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_threshold_exceeded() {
+        // CoV > threshold → "exceeds threshold"
+        let aggregates = vec![100.0, 115.0, 90.0, 120.0, 85.0, 110.0];
+        let out = format_output("bench", &aggregates, true, 60, "group", Some(5.0));
+        assert!(
+            out.contains("exceeds threshold"),
+            "high CoV with low threshold:\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_threshold_passed() {
+        // CoV < threshold → "within threshold"
+        let aggregates = vec![100.0, 100.5, 99.5, 100.2, 100.8, 99.8];
+        let out = format_output("bench", &aggregates, true, 6, "group", Some(50.0));
+        assert!(
+            out.contains("within threshold"),
+            "low CoV with high threshold:\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_mad_outlier_comment() {
+        // n=5, outlier → low MAD/σ → "outliers" comment in config block
+        let aggregates = vec![100.0, 100.0, 100.0, 100.0, 200.0];
+        let out = format_output("bench", &aggregates, true, 5, "group", None);
+        assert!(
+            out.contains("outliers"),
+            "low MAD/σ with n>=5 should show outliers comment:\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_no_mad_comment_n_lt_5() {
+        // n=4, same pattern → no "outliers" comment because n < 5
+        let aggregates = vec![100.0, 100.0, 100.0, 200.0];
+        let out = format_output("bench", &aggregates, true, 4, "group", None);
+        assert!(
+            !out.contains("outliers"),
+            "n=4 should NOT show outliers comment:\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_cov_numeric_in_output() {
+        // For tight data, CoV should appear as a small % (< 2%), not thousands%
+        // This catches mutations to the CoV division formula
+        let aggregates = vec![100.0, 100.5, 99.5, 100.2, 100.8, 99.8];
+        let out = format_output("bench", &aggregates, false, 6, "group", None);
+        assert!(out.contains("Overall CoV"), "fallback label:\n{out}");
+        // "stable" verdict only appears when CoV < 10%; mutating / to * gives CoV ≈ 5000%
+        assert!(
+            out.contains("stable"),
+            "small CoV should give stable:\n{out}"
+        );
+        // MAD% and MAD/σ should be present (not N/A) for valid data
+        assert!(
+            !out.contains("MAD%: N/A"),
+            "MAD% should not be N/A for valid data:\n{out}"
+        );
+        assert!(
+            !out.contains("MAD/σ: N/A"),
+            "MAD/σ should not be N/A for valid data:\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_fallback_grouping_note() {
+        let aggregates = vec![100.0, 105.0, 95.0];
+        let out = format_output("bench", &aggregates, false, 3, "group", None);
+        assert!(out.contains("raw measurements"), "fallback note:\n{out}");
+        assert!(out.contains("no 'group' key"), "missing key note:\n{out}");
     }
 
     #[test]

--- a/git_perf/src/study.rs
+++ b/git_perf/src/study.rs
@@ -101,6 +101,8 @@ pub fn compute_recommendations(aggregates: &[f64]) -> Option<Recommendations> {
     // NaN from compute_mad_sigma_ratio (near-zero stddev) maps to "stddev" via is_mad_preferred
     let mad_sigma_ratio = compute_mad_sigma_ratio(stats.mad, stats.stddev);
 
+    // Low MAD/σ means outliers inflate stddev relative to MAD, making MAD the
+    // more robust dispersion method for detecting genuine regressions.
     let dispersion_method = if is_mad_preferred(mad_sigma_ratio, aggregates.len()) {
         "mad"
     } else {

--- a/git_perf/src/study.rs
+++ b/git_perf/src/study.rs
@@ -65,6 +65,12 @@ fn group_measurements(measurements: &[&MeasurementData], key: &str) -> GroupedSt
     }
 }
 
+/// Returns true if MAD is preferred over stddev as the dispersion method.
+/// Requires a low MAD/σ ratio (outliers present) AND at least 5 data points.
+fn is_mad_preferred(mad_sigma_ratio: f64, n: usize) -> bool {
+    mad_sigma_ratio < 0.7 && n >= 5
+}
+
 /// Compute recommendations from between-group aggregate values.
 /// Returns None if there are fewer than 3 data points.
 #[must_use]
@@ -84,7 +90,7 @@ pub fn compute_recommendations(aggregates: &[f64]) -> Option<Recommendations> {
         1.0
     };
 
-    let dispersion_method = if mad_sigma_ratio < 0.7 && aggregates.len() >= 5 {
+    let dispersion_method = if is_mad_preferred(mad_sigma_ratio, aggregates.len()) {
         "mad"
     } else {
         "stddev"
@@ -231,7 +237,7 @@ pub(crate) fn format_output(
              \n  dispersion_method = \"{method}\"",
             method = recs.dispersion_method,
         ));
-        if mad_sigma_ratio < 0.7 && n >= 5 && !mad_sigma_ratio.is_nan() {
+        if is_mad_preferred(mad_sigma_ratio, n) && !mad_sigma_ratio.is_nan() {
             out.push_str(&format!(
                 "  # MAD/σ = {:.2} — outliers between runners detected",
                 mad_sigma_ratio
@@ -623,5 +629,19 @@ mod tests {
         assert!(!grouped.grouped_by_key);
         assert_eq!(grouped.group_aggregates.len(), 3);
         assert_eq!(grouped.total_raw, 3);
+    }
+
+    #[test]
+    fn test_is_mad_preferred_boundary() {
+        // At the exact literal boundary 0.7: strict < is false, <= would be true — kills < vs <= mutant
+        assert!(!is_mad_preferred(0.7, 5));
+        // Below threshold: < and <= both true
+        assert!(is_mad_preferred(0.6, 5));
+        // Above threshold: < and <= both false
+        assert!(!is_mad_preferred(0.8, 5));
+        // n=4 boundary: never preferred regardless of ratio
+        assert!(!is_mad_preferred(0.5, 4));
+        // n=5 with low ratio: preferred
+        assert!(is_mad_preferred(0.5, 5));
     }
 }

--- a/git_perf/src/study.rs
+++ b/git_perf/src/study.rs
@@ -84,11 +84,8 @@ pub fn compute_recommendations(aggregates: &[f64]) -> Option<Recommendations> {
     }
 
     let cov = stats.stddev / stats.mean * 100.0;
-    let mad_sigma_ratio = if stats.stddev > f64::EPSILON {
-        stats.mad / stats.stddev
-    } else {
-        1.0
-    };
+    // NaN from compute_mad_sigma_ratio (near-zero stddev) maps to "stddev" via is_mad_preferred
+    let mad_sigma_ratio = compute_mad_sigma_ratio(stats.mad, stats.stddev);
 
     let dispersion_method = if is_mad_preferred(mad_sigma_ratio, aggregates.len()) {
         "mad"
@@ -438,12 +435,93 @@ mod tests {
         // compute_mad_pct: near-zero mean → NaN
         assert!(compute_mad_pct(1.0, 0.0).is_nan());
 
+        // compute_mad_pct: exact-EPSILON mean → NaN (EPSILON > EPSILON is false)
+        assert!(compute_mad_pct(1.0, f64::EPSILON).is_nan());
+
         // compute_mad_sigma_ratio: normal input
         let r = compute_mad_sigma_ratio(3.0, 6.0);
         assert!((r - 0.5).abs() < 1e-9, "ratio should be 0.5, got {r}");
 
         // compute_mad_sigma_ratio: near-zero stddev → NaN
         assert!(compute_mad_sigma_ratio(1.0, 0.0).is_nan());
+
+        // compute_mad_sigma_ratio: exact-EPSILON stddev → NaN (EPSILON > EPSILON is false)
+        assert!(compute_mad_sigma_ratio(1.0, f64::EPSILON).is_nan());
+    }
+
+    #[test]
+    fn test_recommendations_near_zero_mean_guard() {
+        // mean = EPSILON → should return None (|| with && mutation would continue instead)
+        // data sums to 3*EPSILON so mean = EPSILON (well below practical significance)
+        let eps_data = vec![f64::EPSILON, f64::EPSILON, f64::EPSILON];
+        assert!(
+            compute_recommendations(&eps_data).is_none(),
+            "near-zero mean should give None"
+        );
+    }
+
+    #[test]
+    fn test_recommendations_at_exact_cov_boundaries() {
+        // [95, 95, 100, 105, 105]: Welford's algorithm for symmetric data gives stddev that
+        // via compute_recommendations cov = stddev/mean*100 lands at or below 5.0, meaning
+        // cov > 5.0 is FALSE → sigma = 4.0. This kills the > 5.0 → >= 5.0 mutant.
+        let data_near_5pct = vec![95.0, 95.0, 100.0, 105.0, 105.0];
+        let recs = compute_recommendations(&data_near_5pct).unwrap();
+        assert!(
+            (recs.sigma - 4.0).abs() < f64::EPSILON,
+            "cov ≤ 5.0: sigma should be 4.0, got {}",
+            recs.sigma
+        );
+        assert_eq!(
+            recs.aggregate_by, "min",
+            "cov ≤ 5.0: should use min aggregation"
+        );
+        assert_eq!(recs.min_measurements, 3, "cov ≤ 5.0: min_measurements = 3");
+    }
+
+    #[test]
+    fn test_format_output_config_block_comments() {
+        // Low CoV (≈ 0.5%): no CoV-threshold config comments
+        let low_cov = vec![100.0, 100.5, 99.5, 100.2, 100.8, 99.8];
+        let out_low = format_output("bench", &low_cov, true, 6, "group", None);
+        assert!(
+            !out_low.contains("tightened threshold"),
+            "low CoV should NOT have sigma tightened comment:\n{out_low}"
+        );
+        assert!(
+            !out_low.contains("CoV > 10%"),
+            "low CoV should NOT have CoV>10% config comment:\n{out_low}"
+        );
+
+        // High CoV (≈ 12%): sigma and CoV>10% comments should appear
+        let high_cov = vec![100.0, 112.0, 88.0, 115.0, 85.0, 110.0];
+        let out_high = format_output("bench", &high_cov, true, 60, "group", None);
+        assert!(
+            out_high.contains("tightened threshold"),
+            "high CoV should have sigma tightened comment:\n{out_high}"
+        );
+        assert!(
+            out_high.contains("CoV > 10%"),
+            "high CoV should have CoV>10% config comment:\n{out_high}"
+        );
+    }
+
+    #[test]
+    fn test_format_output_at_cov_boundaries() {
+        // [95, 95, 100, 105, 105]: Welford's algorithm gives stddev that via
+        // compute_cov_pct lands at or below 5.0 in format_output, meaning
+        // cov > 5.0 is FALSE → no sigma "tightened threshold" comment.
+        // This kills the > 5.0 → >= 5.0 mutant in format_output.
+        let data_near_5pct = vec![95.0, 95.0, 100.0, 105.0, 105.0];
+        let out_5 = format_output("bench", &data_near_5pct, true, 5, "group", None);
+        assert!(
+            !out_5.contains("tightened threshold"),
+            "cov ≤ 5.0: no sigma tightened comment:\n{out_5}"
+        );
+        assert!(
+            out_5.contains("stable"),
+            "cov ≤ 5.0: should show stable verdict:\n{out_5}"
+        );
     }
 
     #[test]

--- a/git_perf/src/study.rs
+++ b/git_perf/src/study.rs
@@ -1,0 +1,439 @@
+use std::collections::HashMap;
+
+use anyhow::{bail, Result};
+use readable::num::Float;
+
+use crate::{
+    data::MeasurementData,
+    measurement_retrieval,
+    stats::{aggregate_measurements, NumericReductionFunc, ReductionFunc},
+};
+
+pub struct Recommendations {
+    pub dispersion_method: &'static str,
+    pub aggregate_by: &'static str,
+    pub sigma: f64,
+    pub min_measurements: u16,
+    pub min_relative_deviation: f64,
+    pub max_cov: f64,
+}
+
+struct GroupedStudy {
+    /// Per-group aggregated values (one per independent runner instance)
+    group_aggregates: Vec<f64>,
+    /// Total raw measurement count across all groups
+    total_raw: usize,
+    /// Whether grouping by key succeeded (vs. raw fallback)
+    grouped_by_key: bool,
+}
+
+fn group_measurements(measurements: &[&MeasurementData], key: &str) -> GroupedStudy {
+    let total_raw = measurements.len();
+    let mut groups: HashMap<String, Vec<f64>> = HashMap::new();
+    for m in measurements {
+        let group_val = m.key_values.get(key).cloned().unwrap_or_default();
+        groups.entry(group_val).or_default().push(m.val);
+    }
+
+    // Only use grouped CoV if the key is actually present and produces ≥2 groups
+    // (a single group keyed by "" means no runner tagged their measurements).
+    let non_empty_key_groups = groups.keys().filter(|k| !k.is_empty()).count();
+    if non_empty_key_groups >= 2 {
+        let group_aggregates = groups
+            .iter()
+            .filter(|(k, _)| !k.is_empty())
+            .map(|(_, vals)| {
+                vals.iter()
+                    .cloned()
+                    .aggregate_by(ReductionFunc::Min)
+                    .unwrap_or(f64::NAN)
+            })
+            .collect();
+        GroupedStudy {
+            group_aggregates,
+            total_raw,
+            grouped_by_key: true,
+        }
+    } else {
+        // Fallback: treat each raw measurement as an independent sample
+        let group_aggregates = measurements.iter().map(|m| m.val).collect();
+        GroupedStudy {
+            group_aggregates,
+            total_raw,
+            grouped_by_key: false,
+        }
+    }
+}
+
+/// Compute recommendations from between-group aggregate values.
+/// Returns None if there are fewer than 3 data points.
+#[must_use]
+pub fn compute_recommendations(aggregates: &[f64]) -> Option<Recommendations> {
+    if aggregates.len() < 3 {
+        return None;
+    }
+    let stats = aggregate_measurements(aggregates.iter());
+    if stats.mean.abs() <= f64::EPSILON || stats.mean.is_nan() {
+        return None;
+    }
+
+    let cov = stats.stddev / stats.mean * 100.0;
+    let mad_sigma_ratio = if stats.stddev > f64::EPSILON {
+        stats.mad / stats.stddev
+    } else {
+        1.0
+    };
+
+    let dispersion_method = if mad_sigma_ratio < 0.7 && aggregates.len() >= 5 {
+        "mad"
+    } else {
+        "stddev"
+    };
+    let aggregate_by = if cov > 10.0 { "median" } else { "min" };
+    let sigma = if cov > 5.0 { 3.5_f64 } else { 4.0_f64 };
+    let min_measurements: u16 = if cov > 10.0 { 5 } else { 3 };
+    // Round up to nearest 0.5 for readability
+    let min_relative_deviation = (cov * 1.5 * 2.0).ceil() / 2.0;
+    let max_cov = (cov * 2.0 * 2.0).ceil() / 2.0;
+
+    Some(Recommendations {
+        dispersion_method,
+        aggregate_by,
+        sigma,
+        min_measurements,
+        min_relative_deviation,
+        max_cov,
+    })
+}
+
+fn format_output(
+    name: &str,
+    aggregates: &[f64],
+    grouped_by_key: bool,
+    total_raw: usize,
+    group_by: &str,
+    max_cov_threshold: Option<f64>,
+) -> String {
+    let stats = aggregate_measurements(aggregates.iter());
+    let n = aggregates.len();
+    let cov = if stats.mean.abs() > f64::EPSILON && !stats.mean.is_nan() {
+        stats.stddev / stats.mean * 100.0
+    } else {
+        f64::NAN
+    };
+    let mad_pct = if stats.mean.abs() > f64::EPSILON && !stats.mean.is_nan() {
+        stats.mad / stats.mean.abs() * 100.0
+    } else {
+        f64::NAN
+    };
+    let mad_sigma_ratio = if stats.stddev > f64::EPSILON {
+        stats.mad / stats.stddev
+    } else {
+        f64::NAN
+    };
+
+    let cov_label = if grouped_by_key {
+        "Between-group CoV"
+    } else {
+        "Overall CoV (no group key found)"
+    };
+
+    let grouping_note = if grouped_by_key {
+        format!(
+            "{n} groups × {} reps (grouped by: {group_by})",
+            total_raw / n
+        )
+    } else {
+        format!(
+            "{total_raw} raw measurements (no '{group_by}' key found — \
+             tag runners with --key-value {group_by}=<instance> for between-runner CoV)"
+        )
+    };
+
+    let cov_str = if cov.is_nan() {
+        "N/A".to_string()
+    } else {
+        format!("{:.1}%", cov)
+    };
+    let mad_pct_str = if mad_pct.is_nan() {
+        "N/A".to_string()
+    } else {
+        format!("{:.1}%", mad_pct)
+    };
+    let mad_sigma_str = if mad_sigma_ratio.is_nan() {
+        "N/A".to_string()
+    } else {
+        format!("{:.2}", mad_sigma_ratio)
+    };
+
+    let mut out = format!(
+        "📊 '{}' — {}\n  μ: {} | σ: {} | MAD: {}\n  {}: {} | MAD%: {} | MAD/σ: {}\n",
+        name,
+        grouping_note,
+        Float::from(stats.mean),
+        Float::from(stats.stddev),
+        Float::from(stats.mad),
+        cov_label,
+        cov_str,
+        mad_pct_str,
+        mad_sigma_str,
+    );
+
+    // CoV verdict
+    if !cov.is_nan() {
+        let verdict = if let Some(threshold) = max_cov_threshold {
+            if cov > threshold {
+                format!(
+                    "\n  ⚠️  CoV {:.1}% exceeds threshold {:.1}% — \
+                     benchmark may produce unreliable CI results.\n\
+                     Consider: increasing workload size, adding warmup, \
+                     or reducing setup variance.",
+                    cov, threshold
+                )
+            } else {
+                format!(
+                    "\n  ✅ CoV {:.1}% is within threshold {:.1}%.",
+                    cov, threshold
+                )
+            }
+        } else if cov > 20.0 {
+            "\n  ⚠️  CoV > 20%: benchmark is too noisy for reliable regression detection.\n\
+             Consider increasing workload size or reducing setup variance."
+                .to_string()
+        } else if cov > 10.0 {
+            "\n  ⚠️  CoV 10–20%: moderate noise. Monitor with max_cov in config.".to_string()
+        } else {
+            "\n  ✅ CoV < 10%: benchmark is stable.".to_string()
+        };
+        out.push_str(&verdict);
+    }
+
+    // Recommended config
+    if let Some(recs) = compute_recommendations(aggregates) {
+        out.push_str(&format!(
+            "\n\n  Recommended .gitperfconfig:\n\
+             \n  [measurement.\"{name}\"]\n\
+             \n  dispersion_method = \"{method}\"",
+            method = recs.dispersion_method,
+        ));
+        if mad_sigma_ratio < 0.7 && n >= 5 && !mad_sigma_ratio.is_nan() {
+            out.push_str(&format!(
+                "  # MAD/σ = {:.2} — outliers between runners detected",
+                mad_sigma_ratio
+            ));
+        }
+        out.push_str(&format!("\n  sigma = {}", recs.sigma));
+        if cov > 5.0 {
+            out.push_str("  # tightened threshold for CoV > 5%");
+        }
+        out.push_str(&format!("\n  aggregate_by = \"{}\"", recs.aggregate_by));
+        if cov > 10.0 {
+            out.push_str("  # CoV > 10% → median more stable than min");
+        }
+        out.push_str(&format!("\n  min_measurements = {}", recs.min_measurements));
+        if cov > 10.0 {
+            out.push_str("  # CoV > 10% → need more history");
+        }
+        out.push_str(&format!(
+            "\n  min_relative_deviation = {}  # 1.5× between-group CoV — noise floor",
+            recs.min_relative_deviation
+        ));
+        out.push_str(&format!(
+            "\n  max_cov = {}  # warn if noise grows to 2× current level\n",
+            recs.max_cov
+        ));
+    } else {
+        out.push_str(
+            "\n\n  Not enough data points for recommendations (need ≥ 3 groups).\n\
+             Run the benchmark on more independent runner instances.",
+        );
+    }
+
+    out
+}
+
+pub fn run_study(
+    commit: &str,
+    max_count: usize,
+    name: &str,
+    max_cov_threshold: Option<f64>,
+    group_by: &str,
+) -> Result<()> {
+    let commits: Vec<_> =
+        measurement_retrieval::walk_commits_from(commit, max_count, None, None)?.collect();
+
+    let head_measurements: Vec<&MeasurementData> = commits
+        .first()
+        .and_then(|r| r.as_ref().ok())
+        .map(|c| c.measurements.iter().filter(|m| m.name == name).collect())
+        .unwrap_or_default();
+
+    if head_measurements.is_empty() {
+        bail!(
+            "No measurements found for '{}' at HEAD.\n\
+             Have you run 'git-perf measure' or 'git-perf push && git-perf pull'?",
+            name
+        );
+    }
+
+    let GroupedStudy {
+        group_aggregates,
+        total_raw,
+        grouped_by_key,
+    } = group_measurements(&head_measurements, group_by);
+
+    if group_aggregates.len() < 3 {
+        bail!(
+            "Need at least 3 independent data points for a reliable study (found {}).\n\
+             Run the benchmark on more independent runner instances and tag each with:\n\
+               --key-value {}=<instance_number>",
+            group_aggregates.len(),
+            group_by
+        );
+    }
+
+    let output = format_output(
+        name,
+        &group_aggregates,
+        grouped_by_key,
+        total_raw,
+        group_by,
+        max_cov_threshold,
+    );
+    print!("{}", output);
+
+    if let Some(threshold) = max_cov_threshold {
+        let stats = aggregate_measurements(group_aggregates.iter());
+        let cov = if stats.mean.abs() > f64::EPSILON {
+            stats.stddev / stats.mean * 100.0
+        } else {
+            0.0
+        };
+        if cov > threshold {
+            bail!("CoV {:.1}% exceeds threshold {:.1}%", cov, threshold);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_uniform(vals: &[f64]) -> Vec<f64> {
+        vals.to_vec()
+    }
+
+    #[test]
+    fn test_recommend_low_cov() {
+        // Very tight data → low CoV → stddev, min, sigma=4.0, min_measurements=3
+        let data = make_uniform(&[100.0, 101.0, 100.5, 99.5, 100.2, 100.8]);
+        let recs = compute_recommendations(&data).expect("should have recommendations");
+        assert_eq!(recs.dispersion_method, "stddev");
+        assert_eq!(recs.aggregate_by, "min");
+        assert!((recs.sigma - 4.0).abs() < f64::EPSILON);
+        assert_eq!(recs.min_measurements, 3);
+        // min_relative_deviation should be small (CoV < 5%)
+        assert!(recs.min_relative_deviation < 10.0);
+    }
+
+    #[test]
+    fn test_recommend_high_cov() {
+        // Wide spread → high CoV > 10% → mad, median, sigma=3.5, min_measurements=5
+        let data: Vec<f64> = vec![100.0, 115.0, 90.0, 120.0, 85.0, 110.0, 95.0, 125.0];
+        let recs = compute_recommendations(&data).expect("should have recommendations");
+        // High CoV should trigger median and more min_measurements
+        assert_eq!(recs.aggregate_by, "median");
+        assert_eq!(recs.min_measurements, 5);
+        assert!((recs.sigma - 3.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_recommend_insufficient_data() {
+        assert!(compute_recommendations(&[100.0]).is_none());
+        assert!(compute_recommendations(&[100.0, 101.0]).is_none());
+        assert!(compute_recommendations(&[]).is_none());
+    }
+
+    #[test]
+    fn test_recommend_rounding() {
+        // CoV = 8.4% → min_relative_deviation = ceil(8.4 * 1.5 * 2) / 2 = ceil(25.2) / 2 = 26/2 = 13.0
+        // We can't easily control exact CoV, but check that rounding is to nearest 0.5
+        let recs = compute_recommendations(&[100.0, 108.0, 100.5, 107.5, 99.5, 108.5]).unwrap();
+        // Result should be a multiple of 0.5
+        let scaled = recs.min_relative_deviation * 2.0;
+        assert!(
+            (scaled - scaled.round()).abs() < f64::EPSILON,
+            "min_relative_deviation should be a multiple of 0.5"
+        );
+        let scaled_cov = recs.max_cov * 2.0;
+        assert!(
+            (scaled_cov - scaled_cov.round()).abs() < f64::EPSILON,
+            "max_cov should be a multiple of 0.5"
+        );
+    }
+
+    #[test]
+    fn test_group_by_key() {
+        let mut m1 = MeasurementData {
+            epoch: 0,
+            name: "t".to_string(),
+            timestamp: 0.0,
+            val: 100.0,
+            key_values: std::collections::HashMap::new(),
+        };
+        m1.key_values.insert("group".to_string(), "1".to_string());
+
+        let mut m2 = m1.clone();
+        m2.val = 200.0;
+        m2.key_values.insert("group".to_string(), "2".to_string());
+
+        let mut m3 = m1.clone();
+        m3.val = 300.0;
+        m3.key_values.insert("group".to_string(), "3".to_string());
+
+        // Add a second rep to group 1 (lower value — should be min)
+        let mut m1b = m1.clone();
+        m1b.val = 90.0;
+
+        let measurements = vec![&m1, &m1b, &m2, &m3];
+        let grouped = group_measurements(&measurements, "group");
+
+        assert!(grouped.grouped_by_key);
+        assert_eq!(grouped.group_aggregates.len(), 3);
+        assert_eq!(grouped.total_raw, 4);
+
+        // Group 1 should have min(100, 90) = 90
+        assert!(grouped.group_aggregates.contains(&90.0));
+        assert!(grouped.group_aggregates.contains(&200.0));
+        assert!(grouped.group_aggregates.contains(&300.0));
+    }
+
+    #[test]
+    fn test_group_by_key_fallback() {
+        // No group key → fallback to raw values
+        let m1 = MeasurementData {
+            epoch: 0,
+            name: "t".to_string(),
+            timestamp: 0.0,
+            val: 100.0,
+            key_values: std::collections::HashMap::new(),
+        };
+        let m2 = MeasurementData {
+            val: 110.0,
+            ..m1.clone()
+        };
+        let m3 = MeasurementData {
+            val: 95.0,
+            ..m1.clone()
+        };
+
+        let measurements = vec![&m1, &m2, &m3];
+        let grouped = group_measurements(&measurements, "group");
+
+        assert!(!grouped.grouped_by_key);
+        assert_eq!(grouped.group_aggregates.len(), 3);
+        assert_eq!(grouped.total_raw, 3);
+    }
+}

--- a/man/man1/git-perf-study.1
+++ b/man/man1/git-perf-study.1
@@ -40,7 +40,7 @@ Fail if between\-group CoV exceeds this percentage
 Target commit to study (default: HEAD)
 .TP
 \fB\-\-group\-by\fR \fI<GROUP_BY>\fR [default: group]
-Metadata key used to identify independent runner groups. Each matrix instance should tag its measurements with \-\-key\-value <group\-by>=<instance\-number>
+Metadata key used to identify independent runner groups. Each matrix instance should tag its measurements with `\-\-key\-value <KEY>=<INSTANCE_NUMBER>`
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/man1/git-perf-study.1
+++ b/man/man1/git-perf-study.1
@@ -1,0 +1,46 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH study 1  "study " 
+.SH NAME
+study \- Analyze cross\-runner variance to recommend .gitperfconfig settings
+.SH SYNOPSIS
+\fBstudy\fR <\fB\-m\fR|\fB\-\-measurement\fR> [\fB\-n\fR|\fB\-\-max\-count\fR] [\fB\-\-max\-cov\fR] [\fB\-\-commit\fR] [\fB\-\-group\-by\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Analyze cross\-runner variance to recommend .gitperfconfig settings
+.PP
+Reads measurements at HEAD that were collected from multiple independent runner instances (each tagged with a group key via \-\-key\-value group=N), computes between\-group CoV (Coefficient of Variation), and outputs recommended .gitperfconfig parameters.
+.PP
+## Workflow
+.PP
+1. Run the benchmark on N independent CI runners (use a matrix strategy). Each runner stores its measurements and tags them with a group key: `git\-perf measure \-n 10 \-m MEASUREMENT \-\-key\-value group=$INSTANCE \-\- COMMAND` `git\-perf push`
+.PP
+2. After all runners finish, pull and run study: `git\-perf pull` `git\-perf study \-m MEASUREMENT`
+.PP
+## Interpretation
+.PP
+\- CoV < 10%: stable benchmark — use the recommended config as\-is \- CoV 10–20%: moderate noise — monitor with max_cov and consider increasing workload \- CoV > 20%: too noisy — improve benchmark isolation before merging
+.PP
+## Examples
+.PP
+```bash # Analyze cross\-runner variance for a specific measurement git\-perf study \-m bench::add_measurements/add_measurement/1::median
+.PP
+# Fail if CoV exceeds 20% (useful as a CI gate on PRs) git\-perf study \-m bench::my_benchmark \-\-max\-cov 20 ```
+.SH OPTIONS
+.TP
+\fB\-m\fR, \fB\-\-measurement\fR \fI<NAME>\fR
+Name of the measurement to analyze
+.TP
+\fB\-n\fR, \fB\-\-max\-count\fR \fI<MAX_COUNT>\fR [default: 50]
+Limit the number of previous commits considered (HEAD is included)
+.TP
+\fB\-\-max\-cov\fR \fI<MAX_COV>\fR
+Fail if between\-group CoV exceeds this percentage
+.TP
+\fB\-\-commit\fR \fI<COMMIT>\fR
+Target commit to study (default: HEAD)
+.TP
+\fB\-\-group\-by\fR \fI<GROUP_BY>\fR [default: group]
+Metadata key used to identify independent runner groups. Each matrix instance should tag its measurements with \-\-key\-value <group\-by>=<instance\-number>
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/man1/git-perf.1
+++ b/man/man1/git-perf.1
@@ -57,6 +57,9 @@ List all commits that have performance measurements
 git\-perf\-size(1)
 Estimate storage size of live performance measurements
 .TP
+git\-perf\-study(1)
+Analyze cross\-runner variance to recommend .gitperfconfig settings
+.TP
 git\-perf\-config(1)
 Manage git\-perf configuration
 .TP

--- a/test/test_study.sh
+++ b/test/test_study.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+export TEST_TRACE=0
+
+script_dir=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
+# shellcheck source=test/common.sh
+source "$script_dir/common.sh"
+
+test_section "study: grouped measurements produce recommendations"
+cd_empty_repo
+create_commit
+# Simulate 10 independent runner instances each contributing 1 measurement
+# with a group key. Values are close together (low CoV ≈ 2-3%).
+for i in $(seq 1 10); do
+  git perf add -m bench::my_op --key-value group="$i" $((100 + i))
+done
+
+assert_success_with_output output git perf study -m bench::my_op
+assert_contains "$output" "Between-group CoV"
+assert_contains "$output" "dispersion_method"
+assert_contains "$output" "sigma"
+assert_contains "$output" "min_relative_deviation"
+assert_contains "$output" "max_cov"
+assert_contains "$output" "[measurement.\"bench::my_op\"]"
+
+test_section "study: fallback to raw CoV when no group key"
+cd_empty_repo
+create_commit
+for i in $(seq 1 5); do
+  git perf add -m raw_op $((200 + i * 5))
+done
+
+assert_success_with_output output git perf study -m raw_op
+assert_contains "$output" "Overall CoV (no group key found)"
+assert_contains "$output" "dispersion_method"
+
+test_section "study: --max-cov passes when CoV is low"
+cd_empty_repo
+create_commit
+# Very tight data: all values within 1% of each other → low CoV
+for i in $(seq 1 5); do
+  git perf add -m stable_op --key-value group="$i" 1000
+done
+
+assert_success git perf study -m stable_op --max-cov 50
+
+test_section "study: --max-cov fails when CoV exceeds threshold"
+cd_empty_repo
+create_commit
+# Wide spread: values range 50..150 → CoV ≈ 25%+ → should fail at threshold 5
+for i in 50 75 100 125 150; do
+  git perf add -m noisy_op --key-value group="$i" "$i"
+done
+
+assert_failure git perf study -m noisy_op --max-cov 5
+
+test_section "study: fails with clear message when no measurements"
+cd_empty_repo
+create_commit
+
+assert_failure_with_output output git perf study -m nonexistent
+assert_contains "$output" "No measurements found"
+
+test_section "study: fails with clear message when too few groups"
+cd_empty_repo
+create_commit
+# Only 2 groups: below the 3-group minimum
+git perf add -m few_op --key-value group=1 100
+git perf add -m few_op --key-value group=2 110
+
+assert_failure_with_output output git perf study -m few_op
+assert_contains "$output" "at least 3"

--- a/test/test_study.sh
+++ b/test/test_study.sh
@@ -70,3 +70,14 @@ git perf add -m few_op --key-value group=2 110
 
 assert_failure_with_output output git perf study -m few_op
 assert_contains "$output" "at least 3"
+
+test_section "study: succeeds with exactly 3 groups (minimum boundary)"
+cd_empty_repo
+create_commit
+# Exactly 3 groups: the minimum required for a reliable study.
+# With < 3: 3 < 3 = false → proceeds. With <= 3 (mutant): 3 <= 3 = true → bails.
+git perf add -m min_groups --key-value group=1 100
+git perf add -m min_groups --key-value group=2 105
+git perf add -m min_groups --key-value group=3 110
+
+assert_success git perf study -m min_groups


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `git-perf study` subcommand that reads cross-runner measurements from git-notes and computes between-runner CoV, outputting recommended `.gitperfconfig` parameters (`dispersion_method`, `sigma`, `aggregate_by`, `min_measurements`, `min_relative_deviation`, `max_cov`)
- Adds `.github/workflows/benchmark-study.yml`: reusable workflow (`workflow_call` + `workflow_dispatch`) that external repos can invoke to run the study on a 10-instance matrix before merging a new benchmark
- Adds `docs/benchmark-study.md`: end-user guide covering when/how to trigger, how to interpret CoV verdicts (GREEN < 10%, YELLOW 10–20%, RED > 20%), how to apply recommendations, and tips for reducing noise

## Motivation

The existing CI benchmarks were tuned through a manual "baseline reliability study" (10 CI runs → measure CoV → derive config). This PR gives users the same structured approach for their own new benchmarks, working *before* merging (no historical git-notes data required).

## How it works

1. User adds a wrapper workflow to their repo calling this one via `workflow_call`
2. On PR branch, trigger the study via `workflow_dispatch` with the measurement name and benchmark command
3. The workflow spawns N runners (default 10), each tagged `--key-value group=<instance>`
4. The `study` job pulls all measurements and runs `git-perf study -m NAME`
5. `study` groups by the `group` key, computes per-group min aggregate, then computes between-group CoV
6. Output includes stats + ready-to-paste `.gitperfconfig` TOML

## Test plan

- [x] Unit tests in `study.rs`: `test_recommend_low_cov`, `test_recommend_high_cov`, `test_recommend_insufficient_data`, `test_rounding`, `test_group_by_key`, `test_group_by_key_fallback`
- [x] Bash integration test `test/test_study.sh`: grouped measurements, fallback CoV, `--max-cov` pass/fail, no-measurements error, too-few-groups error
- [x] `cargo fmt` + `cargo clippy` clean
- [x] Man pages regenerated via `./scripts/generate-manpages.sh`

https://claude.ai/code/session_01FmFaEJfK8FDpt68MhGqAQ1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmFaEJfK8FDpt68MhGqAQ1)_