### PR TITLE
ci: fix benchmark-study matrix by using dynamic setup job

### DIFF
--- a/.github/workflows/benchmark-study.yml
+++ b/.github/workflows/benchmark-study.yml
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install git-perf
-        uses: kaihowl/git-perf/.github/actions/install@main
+        uses: kaihowl/git-perf/.github/actions/install@master
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -147,7 +147,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install git-perf
-        uses: kaihowl/git-perf/.github/actions/install@main
+        uses: kaihowl/git-perf/.github/actions/install@master
 
       - name: Pull measurements from all runners
         run: git perf pull

--- a/.github/workflows/benchmark-study.yml
+++ b/.github/workflows/benchmark-study.yml
@@ -101,11 +101,13 @@ jobs:
           # Full history so git-perf can walk commits for push/pull
           fetch-depth: 0
 
-      - name: Install git-perf
-        uses: kaihowl/git-perf/.github/actions/install@master
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Install git-perf from master
+        run: |
+          cargo install --git https://github.com/kaihowl/git-perf --branch master
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Cache cargo registry
         uses: actions/cache@v5
@@ -146,8 +148,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install git-perf
-        uses: kaihowl/git-perf/.github/actions/install@master
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install git-perf from master
+        run: |
+          cargo install --git https://github.com/kaihowl/git-perf --branch master
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Pull measurements from all runners
         run: git perf pull

--- a/.github/workflows/benchmark-study.yml
+++ b/.github/workflows/benchmark-study.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Install git-perf from master
         run: |
-          cargo install --git https://github.com/kaihowl/git-perf --branch master --package git-perf
+          cargo install --git https://github.com/kaihowl/git-perf --branch master git-perf
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Cache cargo registry
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install git-perf from master
         run: |
-          cargo install --git https://github.com/kaihowl/git-perf --branch master --package git-perf
+          cargo install --git https://github.com/kaihowl/git-perf --branch master git-perf
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Pull measurements from all runners

--- a/.github/workflows/benchmark-study.yml
+++ b/.github/workflows/benchmark-study.yml
@@ -68,19 +68,25 @@ on:
         type: string
 
 jobs:
+  setup:
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          n="${{ inputs.instances }}"
+          matrix=$(python3 -c "import json; n=int('$n'); print(json.dumps(list(range(1, n+1))))")
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
   measure:
+    needs: setup
     name: Measure (instance ${{ matrix.instance }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-      # Generate a matrix from 1..instances. GitHub Actions doesn't support
-      # dynamic matrix sizes natively, so we hardcode up to 10 instances and
-      # trim via the 'if' condition below.
       matrix:
-        instance: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-    # Only run the instances the user requested
-    if: ${{ matrix.instance <= fromJSON(inputs.instances) }}
+        instance: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     env:
       GIT_AUTHOR_NAME: github-actions[bot]
@@ -126,7 +132,7 @@ jobs:
     name: Analyze cross-runner variance
     runs-on: ubuntu-22.04
     needs: measure
-    if: always() && needs.measure.result != 'skipped'
+    if: always() && needs.measure.result != 'cancelled'
 
     env:
       GIT_AUTHOR_NAME: github-actions[bot]

--- a/.github/workflows/benchmark-study.yml
+++ b/.github/workflows/benchmark-study.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Install git-perf from master
         run: |
-          cargo install --git https://github.com/kaihowl/git-perf --branch master
+          cargo install --git https://github.com/kaihowl/git-perf --branch master --package git-perf
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Cache cargo registry
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install git-perf from master
         run: |
-          cargo install --git https://github.com/kaihowl/git-perf --branch master
+          cargo install --git https://github.com/kaihowl/git-perf --branch master --package git-perf
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Pull measurements from all runners


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- GitHub Actions does not support the `matrix` context in job-level `if` conditions — only in `steps[*].if`. The original workflow used `if: ${{ matrix.instance <= fromJSON(inputs.instances) }}` at the job level, which fails with "Unrecognized named-value: 'matrix'" at parse time.
- Replaced the hardcoded `instance: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]` matrix + filter with a `setup` job that dynamically generates the exact instance list `[1..instances]` and passes it to the `measure` job via `needs.setup.outputs.matrix`.
- Updated the `study` job condition from `!= 'skipped'` to `!= 'cancelled'` since with a dynamic matrix all instances always run (none are skipped).

## Test plan

- [ ] Trigger `benchmark-study.yml` workflow dispatch on `claude/benchmark-add-measurements-median-N8wwV` with the study parameters — should parse and queue without error
- [ ] Verify `setup` job emits correct matrix JSON for the given `instances` count
- [ ] Verify `measure` jobs fan out to the correct number of instances
- [ ] Verify `study` job runs after all measure jobs complete

https://claude.ai/code/session_01Y1pyJpuSUmqE7jZBA66kgy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1pyJpuSUmqE7jZBA66kgy)_