### PR TITLE
chore(config): update bench::add_measurements CoV thresholds from study

### DIFF
--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -34,12 +34,13 @@ dispersion_method = "mad"
 sigma = 3.5
 aggregate_by = "median"
 min_measurements = 5
-# Baseline reliability study (10 independent CI runs) measured CoV=8.3%, MAD≈3.4%.
-# min_relative_deviation=10% floor suppresses false positives from normal CI jitter
-# (which peaks at ~8%); sigma=3.5 detects sustained regressions above ~10%.
+# Benchmark study (10 independent CI runners × 10 reps) measured CoV=13.8%, MAD%=4.9%.
+# min_relative_deviation=21 (1.5× CoV) suppresses false positives from normal CI jitter.
+# max_cov=28 warns if between-runner noise grows to 2× current level.
 # Epoch bumped to 66c260b: prior stable tail poisoned by a ~5ms outlier measurement
 # which destabilised MAD and caused repeated false-positive audit failures.
-min_relative_deviation = 10.0
+min_relative_deviation = 21
+max_cov = 28
 
 [measurement."add-benchmark"]
 epoch = "296bc41"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Raises `min_relative_deviation` from `10.0` to `21` (1.5× the measured between-runner CoV)
- Adds `max_cov = 28` as a guard rail (2× the measured CoV)

Based on a benchmark study (10 independent CI runners × 10 reps) that measured CoV=13.8% for `bench::add_measurements/add_measurement/1::median`, up from the prior baseline of 8.3%.

## Test plan

- [ ] CI audit passes with new thresholds

https://claude.ai/code/session_01Y1pyJpuSUmqE7jZBA66kgy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1pyJpuSUmqE7jZBA66kgy)_