### PR TITLE
chore(git_perf): bump rust-toolchain to 1.97.1 and fix clippy lint

### DIFF
--- a/git_perf/src/git/git_interop.rs
+++ b/git_perf/src/git/git_interop.rs
@@ -776,7 +776,7 @@ fn git_push_notes_ref(
 
     match output {
         Ok(output) => {
-            print!("{}", &output.stdout);
+            print!("{}", output.stdout);
             Ok(())
         }
         Err(GitError::ExecError { output, .. }) => {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Pin Rust version to prevent unexpected CI breakages from new compiler releases
 # Dependabot will automatically create PRs to update this version
-channel = "1.96.1"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

Fixes the CI failure blocking #747 (Dependabot's `rust-toolchain` bump from 1.96.1 to 1.97.1) by applying the same version bump together with the one-line clippy fix that newer clippy now requires.

## Type of Change

- [x] `fix`: Bug fix
- [x] `chore`: Maintenance tasks (dependencies, build, etc.)

## Changes

- Bump `rust-toolchain.toml` channel from `1.96.1` to `1.97.1` (same change as #747).
- Fix new `clippy::useless_borrows_in_formatting` lint in `git_perf/src/git/git_interop.rs`: `print!("{}", &output.stdout)` → `print!("{}", output.stdout)`.

## Related Issues

Fixes CI on #747

## Testing

- [x] All tests pass: `cargo nextest run -- --skip slow` (443 passed, 1 skipped)
- [x] **Mutation testing passed**: `cargo mutants --test-tool=nextest --in-diff <diff-file>` (1 mutant tested, 1 caught, exit code 0)

**Test results:**
```
Summary [21.308s] 443 tests run: 443 passed, 1 skipped
```

**Mutation testing results:**
```
Found 1 mutant to test
ok       Unmutated baseline in 55.5s build + 21.2s test
1 mutant tested in 1m 23s: 1 caught
```

## Documentation

- [x] No documentation changes needed

## Pre-Submission Checklist

- [x] Code formatted with `cargo fmt`
- [x] Linting passes: `cargo clippy -- -D warnings`
- [x] All tests pass: `cargo nextest run -- --skip slow`
- [x] **Mutation testing passes**: No uncaught mutants in changed code
- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits format
- [x] Branch is up to date with base branch
- [x] No merge conflicts

## Additional Context

The `test (beta)` job on #747 also showed a blocking-audit failure (`bench::add_measurements/add_measurement/50::median` flagged as a significant regression vs. tail history). That appears to be pre-existing runtime noise in the self-referential perf-audit history for the beta/ubuntu-22.04 bucket, unrelated to this toolchain bump or the clippy fix — it isn't touched by this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JjwTBfAUK8p2xTWrmSZFFy)_