### PR TITLE
chore(deps): bump the cargo-dependencies group across 1 directory with 8 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"
@@ -272,9 +272,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bytesize"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "cast"
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.24"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d0237145f33580b89724f75d16950efd3e2c91b2d823917ecb69ec7f84f0"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1032,7 +1032,7 @@ dependencies = [
  "mutants",
  "plotly",
  "quick-xml",
- "rand 0.10.1",
+ "rand 0.10.2",
  "readable",
  "regex",
  "serde",
@@ -1450,9 +1450,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -1703,7 +1703,7 @@ dependencies = [
  "erased-serde",
  "once_cell",
  "plotly_derive",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -1805,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
@@ -2296,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
 dependencies = [
  "libc",
  "memchr",

--- a/git_perf/Cargo.toml
+++ b/git_perf/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1"
 fundu = "2"
 bytesize = "2"
 human-repr = "1"
-quick-xml = { version = "0.40", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 sysinfo = "0.39"
 tempfile = { version = "3.27.0", optional = true }


### PR DESCRIPTION
## Summary

Rebases dependabot's dependency bump (#748) onto current `master`. The original PR predated #749 ("serialize local git push to fix concurrent-push corruption"), which is what caused `test_with_git_versions (v2.54.0)` to fail with `testslow_concurrency_push_add` (git push `unpacker error` / unresolved deltas). Rebasing picks up that fix. The `test (stable)` audit failure on the original PR run was a self-referential CI benchmark flake (HEAD sample vs. tail measurements), unrelated to these dependency version bumps.

## Type of Change

- [x] `chore`: Maintenance tasks (dependencies, build, etc.)

## Changes

- Bump `anyhow` 1.0.102 → 1.0.103
- Bump `env_logger` 0.11.10 → 0.11.11
- Bump `log` 0.4.32 → 0.4.33
- Bump `rand` 0.10.1 → 0.10.2
- Bump `config` 0.15.24 → 0.15.25
- Bump `bytesize` 2.4.0 → 2.4.2
- Bump `quick-xml` 0.40.1 → 0.41.0
- Bump `sysinfo` 0.39.3 → 0.39.5

## Related Issues

Closes #748

## Testing

- [x] All tests pass: `cargo nextest run -- --skip slow --skip test_customheader --skip test_remove` (439 passed, 5 skipped; `test_customheader`/`test_remove` skipped locally due to no IPv6/libfaketime in this sandbox)
- [ ] Added new tests for changes (not applicable — dependency version bump only)
- [ ] Mutation testing (not applicable — no source code changed, only `Cargo.toml`/`Cargo.lock`)
- [x] Manual testing performed (`cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`)

**Test results:**
```
Summary [  25.486s] 439 tests run: 439 passed, 5 skipped
```

## Documentation

- [x] No documentation changes needed

## Pre-Submission Checklist

- [x] Code formatted with `cargo fmt`
- [x] Linting passes: `cargo clippy`
- [x] All tests pass: `cargo nextest run -- --skip slow`
- [x] Mutation testing: not applicable (no source changes)
- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits format
- [x] Branch is up to date with base branch
- [x] No merge conflicts

## Additional Context

Original dependabot PR: #748.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJoqCU9q2VzjjRnJoS8xt1)_